### PR TITLE
Call steal.startup() instead of steal.import

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,9 @@ module.exports = function(cfg){
 	// Ensure the extension is loaded before the main.
 	loadExtension(loader);
 
-	var startup = steal.import(loader.main).then(function(autorender){
+	var startup = steal.startup().then(function(autorender){
+		// startup returns an Array in dev
+		autorender = Array.isArray(autorender) ? autorender[0] : autorender;
 		return autorender.importPromise || Promise.resolve(autorender);
 	});
 


### PR DESCRIPTION
This will fix #12. Problem was that by calling
`steal.import(loader.main` when `main` is defined in config would cause
an error. What we really want to do here is startup so that is what will
be called now.