### PR TITLE
Remove dependency on can/route/pushstate

### DIFF
--- a/app-map.js
+++ b/app-map.js
@@ -1,4 +1,4 @@
-steal("can/util", "can/map", "can/compute", "can/route/pushstate/", function(can){
+steal("can/util", "can/map", "can/compute", function(can){
 
 	function sortedSetJson(set){
 		if(set == null) {


### PR DESCRIPTION
I'm not sure why we were importing that, I think there was a mistaken
believe that it was needed to make server-side rendering work, but since
the application will be importing pushstate itself it is not needed
here. Fixes #16 