### PR TITLE
Add a System.renderingLoader for plugin use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
-script: node_modules/.bin/grunt test
+script: node_modules/.bin/grunt && npm test
 node_js:
   - "0.10"
   - "node"
   - "iojs"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,12 +2,6 @@
 module.exports = function(grunt){
 
 	grunt.initConfig({
-		simplemocha: {
-			test: {
-				src: ["test/test.js"]
-			}
-		},
-
 		copy: {
 			toTest: {
 				files: [{
@@ -33,8 +27,6 @@ module.exports = function(grunt){
 	});
 
 	grunt.loadNpmTasks("grunt-contrib-copy");
-	grunt.loadNpmTasks("grunt-simple-mocha");
 
-	grunt.registerTask("test", ["copy", "simplemocha"]);
 	grunt.registerTask("default", ["copy"]);
 };

--- a/lib/load_extension.js
+++ b/lib/load_extension.js
@@ -19,11 +19,21 @@ module.exports = function(loader){
 	// Alias our module with the default, that way we can require can
 	aliasNpm(loader, path.resolve(__dirname+"/.."));
 
+	overrideConfig(loader);
+
 	// Ensure the extension loads before the main.
 	var loaderImport = loader.import;
 	loader.import = function(name){
 		if(name === loader.main) {
 			var args = arguments;
+
+			// Set up the renderingLoader to be used by plugins to know what root
+			// to attach urls to.
+			if(!loader.renderingLoader) {
+				loader.renderingLoader = loader.clone();
+				loader.renderingLoader.baseURL = loader.renderingBaseURL || loader.baseURL;
+			}
+
 
 			return loader.import("steal-server-side-render").then(function(){
 				return loaderImport.apply(loader, args);
@@ -32,3 +42,25 @@ module.exports = function(loader){
 		return loaderImport.apply(this, arguments);
 	};
 };
+
+// Override config to prevent the baseURL from being set to something that
+// can't be used to render.
+function overrideConfig(loader){
+	var config = loader.config;
+	loader.config = function(){
+		var res = config.apply(this, arguments);
+
+		var envs = this.envs;
+		if(envs) {
+			Object.keys(envs).forEach(function(key){
+				var config = envs[key];
+				if(config.baseURL) {
+					loader.renderingBaseURL = config.baseURL;
+					delete config.baseURL;
+				}
+			});
+		}
+
+		return res;
+	};
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "can-serve": "./bin/can-serve"
   },
   "scripts": {
-    "test": "mocha test/test.js",
+    "test": "mocha test/test.js && mocha test/test_envs.js && npm run test:browser",
+    "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
@@ -35,7 +36,8 @@
     "grunt-simple-mocha": "^0.4.0",
     "jquery": "^1.11.3",
     "mocha": "^2.2.4",
-    "steal-qunit": "0.0.4"
+    "steal-qunit": "0.0.4",
+    "testee": "^0.2.0"
   },
   "dependencies": {
     "can": "^2.3.0-pre.1",
@@ -44,7 +46,7 @@
     "express": "^4.12.4",
     "http-proxy": "^1.11.1",
     "najax": "^0.1.5",
-    "steal": "^0.10.5",
+    "steal": "^0.11.0-pre.0",
     "xmlhttprequest": "^1.7.0"
   },
   "system": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,17 +4,18 @@ var assert = require("assert");
 var path = require("path");
 
 describe("rendering an app", function(){
-	var render = canSsr({
-		config: __dirname + "/tests/package.json!npm",
-		main: "progressive/index.stache!done-autorender",
-		paths: {
-			"$css": path.resolve(__dirname + "/tests/less_plugin.js")
-		}
+	before(function(){
+		this.render = canSsr({
+			config: __dirname + "/tests/package.json!npm",
+			main: "progressive/index.stache!done-autorender",
+			paths: {
+				"$css": path.resolve(__dirname + "/tests/less_plugin.js")
+			}
+		});
 	});
 
-
 	it("basics works", function(done){
-		render("/").then(function(html){
+		this.render("/").then(function(html){
 			var node = helpers.dom(html);
 
 			var foundHome = false;
@@ -29,7 +30,7 @@ describe("rendering an app", function(){
 	});
 
 	it("works with progressively loaded bundles", function(done){
-		render("/orders").then(function(html){
+		this.render("/orders").then(function(html){
 			var node = helpers.dom(html);
 
 			var found = {};

--- a/test/test_envs.js
+++ b/test/test_envs.js
@@ -1,0 +1,31 @@
+var canSsr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+
+
+describe("rendering an app using envs", function(){
+	before(function(){
+		this.render = canSsr({
+			config: __dirname + "/tests/package.json!npm",
+			main: "envs/index.stache!done-autorender",
+			env: "someenv"
+		});
+	});
+
+	it("works", function(done){
+		this.render("/").then(function(html){
+			var node = helpers.dom(html);
+
+			var found = [];
+			helpers.traverse(node, function(el){
+				if(el.nodeName === "SPAN") {
+					found.push(el);
+				}
+			});
+
+			assert.equal(found[0].innerHTML, "hello bar", "envs config was applied");
+		}).then(done);
+	});
+
+});

--- a/test/tests/envs/index.stache
+++ b/test/tests/envs/index.stache
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<title>envs test</title>
+	</head>
+	<body>
+		<can-import from="envs/state" [.]="{value}" />
+
+		<span>hello {{env}}</span>
+	</body>
+</html>

--- a/test/tests/envs/state.js
+++ b/test/tests/envs/state.js
@@ -1,0 +1,10 @@
+var AppMap = require("app_map");
+
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+module.exports = AppMap.extend({
+	env: function(){
+		return System.FOO;
+	}
+});

--- a/test/tests/package.json
+++ b/test/tests/package.json
@@ -5,5 +5,13 @@
   "dependencies": {
     "can": "2.3.0-pre.1",
     "done-autorender": "0.0.7"
+  },
+  "system": {
+    "envs": {
+      "someenv": {
+		"baseURL": "http://example.com/",
+		"FOO": "bar"
+      }
+    }
   }
 }


### PR DESCRIPTION
This facilitates the create of a System.renderingLoader Loader that is
added after `@config` has loaded. This is where you can add a baseURL
for an environment that should be used by plugins/extensions rather than
the global loader's baseURL which is for the server Steal instance.

Fixes #20