### PR TITLE
properly set the env when running

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,12 @@ var trigger = require("./trigger");
 module.exports = function(cfg){
 	var steal = Steal.clone();
 	var loader = global.System = steal.System;
-	if(process.env.NODE_ENV === "production") {
-		loader.env = "production";
-	}
+
+	loader.config({
+		env: process.env.NODE_ENV === "production" ?
+			"production,server": "server"
+	});
+
 	steal.config(cfg || {});
 
 	// Ensure the extension is loaded before the main.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "can-serve": "./bin/can-serve"
   },
   "scripts": {
-    "test": "mocha test/test.js && mocha test/test_envs.js && npm run test:browser",
+    "test": "npm run test:node && npm run test:browser",
+	"test:node": "mocha test/test.js && mocha test/test_envs.js",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",


### PR DESCRIPTION
This ensures that `server` is one of the listed environments.