### PR TITLE
Do not pass main into canSsr function

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -17,8 +17,7 @@ module.exports = function (config) {
 	var pkgPath = path.join(config.path, 'package.json');
 	var pkg = require(pkgPath);
 	var render = ssr({
-		config: pkgPath + '!npm',
-		main: (pkg.system && pkg.system.main) || pkg.main
+		config: pkgPath + '!npm'
 	});
 
 


### PR DESCRIPTION
This removes the adding of `pkg.main` as an argument into `canSsr` when
running the server. The reason for this removal is that the main is
already defined in the `package.json` file and overriding it will cause
problems when using directories.lib. Fixes #23