### PR TITLE
Update the tests to work with can 2.3.0-pre.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/canjs/ssr",
   "devDependencies": {
-    "done-autorender": "0.0.7",
+    "done-autorender": "^0.3.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^0.8.0",

--- a/test/tests/envs/index.stache
+++ b/test/tests/envs/index.stache
@@ -3,7 +3,7 @@
 		<title>envs test</title>
 	</head>
 	<body>
-		<can-import from="envs/state" [.]="{value}" />
+		<can-import from="envs/state" as="viewModel" />
 
 		<span>hello {{env}}</span>
 	</body>

--- a/test/tests/progressive/index.stache
+++ b/test/tests/progressive/index.stache
@@ -6,7 +6,7 @@
 	</head>
 	<body>
 		<can-import from="progressive/routes"/>
-		<can-import from="progressive/appstate" [.]="{value}" />
+		<can-import from="progressive/appstate" as="viewModel" />
 		<can-import from="progressive/main.css!"/>
 
 		{{#eq page "home"}}


### PR DESCRIPTION
This updates the test to use the new syntax `as="viewModel"`