### PR TITLE
Set a default renderingLoader.baseURL

### DIFF
--- a/lib/load_extension.js
+++ b/lib/load_extension.js
@@ -31,7 +31,12 @@ module.exports = function(loader){
 			// to attach urls to.
 			if(!loader.renderingLoader) {
 				loader.renderingLoader = loader.clone();
-				loader.renderingLoader.baseURL = loader.renderingBaseURL || loader.baseURL;
+				var baseURL = loader.renderingBaseURL || loader.baseURL;
+				if(baseURL.indexOf("file:") === 0) {
+					baseURL = "/";
+				}
+				loader.renderingLoader.baseURL = baseURL;
+
 			}
 
 


### PR DESCRIPTION
When the baseURL is a file: protocol, that is never wanted for the
renderingLoader so just go ahead and set "/" as the default.