### PR TITLE
Normalize module names that are set as bundles

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -18,8 +18,8 @@ loader.set("asset-register", loader.newModule({
 stache.registerHelper("asset", assetHelper);
 stache.registerHelper("isProduction", isProduction);
 
-function setAsBundle(name){
-	return loader.normalize(name).then(function(name) {
+function setAsBundle(name, parentName){
+	return loader.normalize(name, parentName).then(function(name) {
 		if(!bundles[name]) bundles[name] = {};
 	});
 }
@@ -125,9 +125,10 @@ function assetHelper(type){
 }
 
 var loaderImport = loader.import;
-loader.import = function(name){
+loader.import = function(name, options){
 	var loader = this, args = arguments;
-	return setAsBundle(name).then(function(){
+	var parentName = options ? options.name : undefined;
+	return setAsBundle(name, parentName).then(function(){
 		return loaderImport.apply(loader, args);
 	});
 };
@@ -148,6 +149,8 @@ var canImport = can.view.callbacks._tags["can-import"];
 can.view.callbacks._tags["can-import"] = function(el, tagData){
 	var root = tagData.scope.attr("@root");
 	var moduleName = el.getAttribute("from");
+	var templateModule = tagData.options.attr("helpers.module");
+	var parentName = templateModule ? templateModule.id : undefined;
 
 	// Override waitFor temporarily.
 	var waitFor = root.waitFor;
@@ -155,7 +158,7 @@ can.view.callbacks._tags["can-import"] = function(el, tagData){
 		dfd = dfd.then(function(val){
 			var newDfd = new can.Deferred();
 
-			loader.normalize(moduleName).then(function(name){
+			loader.normalize(moduleName, parentName).then(function(name){
 				root.attr("__renderingAssets").push(name);
 				newDfd.resolve(val);
 			});

--- a/test/tests/progressive/index.stache
+++ b/test/tests/progressive/index.stache
@@ -5,7 +5,7 @@
 		{{asset "css"}}
 	</head>
 	<body>
-		<can-import from="progressive/routes"/>
+		<can-import from="./progressive/routes"/>
 		<can-import from="progressive/appstate" as="viewModel" />
 		<can-import from="progressive/main.css!"/>
 


### PR DESCRIPTION
When setting the bundles, make sure to normalize the module name passing
in the parent module name as well.  This fixes a bug where someone could
have:

```html
<can-import from="./app" />
```

Fixes #34