### PR TITLE
Live reload, proxy-to fix and better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ To start a full server that hosts your application run:
 > npm install can-ssr
 > node_modules/.bin/can-server --port 3030
 
-In your application folder. To proxy an API add `--proxy-to url`.
+In your application folder.
+
+Available options:
+
+- __-p, --port__ - Set the port the server should run on
+- __-d, --develop__ - Also starts a live-reload server
+- __-p, --proxy__ <url> - Proxy a local path (default: `/api`) to the given URL (e.g. `http://api.myapp.com`)
+- __-t, --proxy-to <path>__ - Set the proxy endpoint (default: `/api`)
 
 ## Usage
 

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
+var fs = require('fs');
 var program = require('commander');
+
 var pkg = require('../package.json');
 var server = require('../lib/server');
+var exec = require('child_process').exec;
 
 program.version(pkg.version)
   .usage('[options]')
   .description(pkg.description)
+  .option('-d, --develop', 'Enable development mode (live-reload)')
   .option('-p, --port [port]', 'The server port')
   .option('-r, --proxy [url]', 'A URL to an API that should be proxied')
   .option('-t, --proxy-to [path]', 'The path to proxy to (default: /api)')
@@ -20,6 +24,34 @@ if(program.proxy) {
   config.proxyTo = program['proxy-to']
 }
 
-var app = server(config);
+// Spawn a child process in development mode
+if(program.develop) {
+	if(!fs.existsSync('node_modules/.bin/steal-tools')) {
+		console.error('live-reload not available: ' +
+			'No local steal-tools binary found. ' +
+			'Run `npm install steal-tools --save-dev`.')
+	} else {
+		var child = exec('node_modules/.bin/steal-tools live-reload', {
+			cwd: process.cwd()
+		});
 
-app.listen(program.port || process.env.PORT || 3030);
+		child.stdout.pipe(process.stdout);
+		child.stderr.pipe(process.stderr);
+	}
+}
+
+var app = server(config);
+var port = program.port || process.env.PORT || 3030;
+var server = app.listen(port);
+
+server.on('error', function(e) {
+	if(e.code === 'EADDRINUSE') {
+		console.error('ERROR: Can not start can-serve on port ' + port
+			+ '.\nAnother application is already using it.')
+	} else {
+		console.error(e);
+		console.error(e.stack);
+	}
+});
+
+console.log('can-serve starting on port ' + port);

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -21,7 +21,7 @@ var config = {
 
 if(program.proxy) {
   config.proxy = program.proxy;
-  config.proxyTo = program['proxy-to']
+  config.proxyTo = program.proxyTo;
 }
 
 // Spawn a child process in development mode

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -10,9 +10,9 @@ program.version(pkg.version)
   .usage('[options]')
   .description(pkg.description)
   .option('-d, --develop', 'Enable development mode (live-reload)')
-  .option('-p, --port [port]', 'The server port')
-  .option('-r, --proxy [url]', 'A URL to an API that should be proxied')
-  .option('-t, --proxy-to [path]', 'The path to proxy to (default: /api)')
+  .option('-p, --port <port>', 'The server port')
+  .option('-r, --proxy <url>', 'A URL to an API that should be proxied')
+  .option('-t, --proxy-to <path>', 'The path to proxy to (default: /api)')
   .parse(process.argv);
 
 var config = {

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -43,6 +43,9 @@ if(program.develop) {
 var app = server(config);
 var port = program.port || process.env.PORT || 3030;
 var server = app.listen(port);
+var address = server.address();
+var url = 'http://' + (address.address === '::' ?
+		'localhost' : address.address) + ':' + address.port;
 
 server.on('error', function(e) {
 	if(e.code === 'EADDRINUSE') {
@@ -54,4 +57,4 @@ server.on('error', function(e) {
 	}
 });
 
-console.log('can-serve starting on port ' + port);
+console.log('can-serve starting on ' + url);


### PR DESCRIPTION
This pull request adds a `--develop` flag which kicks off a live-reload server as a direct child process. Also fixes `--proxy-to` not working and adds some better error messages.

Fixes #32, fixes #15, closes #31, also closes https://github.com/donejs/donejs/issues/63