### PR TITLE
inline-cache: break up strings with <script> tags

### DIFF
--- a/app-map.js
+++ b/app-map.js
@@ -30,7 +30,7 @@ steal("can/util", "can/map", "can/compute", function(can){
 				register("inline-cache", function(){
 					var script = document.createElement("script");
 					var jsonString = JSON.stringify(self.__pageData);
-					var dataString = jsonString.replace(/script/g, "scr\"+\"ipt");
+					var dataString = jsonString.replace(/(<\/?)script/g, "$1scr\"+\"ipt");
 					var text = document.createTextNode("\nINLINE_CACHE = " + dataString + ";\n")
 					script.appendChild(text);
 					return script;

--- a/app-map.js
+++ b/app-map.js
@@ -29,7 +29,9 @@ steal("can/util", "can/map", "can/compute", function(can){
 				var self = this;
 				register("inline-cache", function(){
 					var script = document.createElement("script");
-					var text = document.createTextNode("\nINLINE_CACHE = " + JSON.stringify(self.__pageData) + ";\n")
+					var jsonString = JSON.stringify(self.__pageData);
+					var dataString = jsonString.replace(/script/g, "scr\"+\"ipt");
+					var text = document.createTextNode("\nINLINE_CACHE = " + dataString + ";\n")
 					script.appendChild(text);
 					return script;
 				});

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -1,5 +1,6 @@
 var AppMap = require("can-ssr/app-map");
 var QUnit = require("steal-qunit");
+var loader = require("@loader");
 
 QUnit.module("can-ssr/app-map");
 
@@ -18,4 +19,22 @@ test("sorts correctly", function(){
 	map.pageData("foo", { "two": 2, "one": 1 }, {});
 
 	equal(keys(map.__pageData).length, 1, "There is one key");
+});
+
+test("Correctly serializes json with scripts in it", function(){
+	var cloneAsset;
+	loader.set("asset-register", loader.newModule({
+		"default": function(name, callback){
+			cloneAsset = callback;
+		}
+	}));
+
+	var map = new AppMap();
+	map.pageData("foo", {foo:"bar"}, {
+		readme: "# hello world\n ```<script type=\"test/stache\">something</script>"
+	});
+
+	debugger;
+
+	QUnit.stop();
 });

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -32,7 +32,7 @@ test("Correctly serializes json with scripts in it", function(){
 
 	var map = new AppMap();
 	map.pageData("foo", {foo:"bar"}, {
-		readme: "# hello world\n ```<script type=\"test/stache\">something</script>"
+		readme: "# hello world\n ```<script type=\"test/stache\">something</script>```"
 	});
 
 	var script = cloneAsset();

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -1,6 +1,7 @@
 var AppMap = require("can-ssr/app-map");
 var QUnit = require("steal-qunit");
 var loader = require("@loader");
+var $ = require("jquery");
 
 QUnit.module("can-ssr/app-map");
 
@@ -34,7 +35,9 @@ test("Correctly serializes json with scripts in it", function(){
 		readme: "# hello world\n ```<script type=\"test/stache\">something</script>"
 	});
 
-	debugger;
+	var script = cloneAsset();
+	$("#qunit-test-area").append(script);
 
-	QUnit.stop();
+	QUnit.ok(window.INLINE_CACHE, "Inline cache exists");
+	QUnit.ok(INLINE_CACHE["{\"foo\":\"bar\"}"], "The set key exists");
 });

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -36,8 +36,10 @@ test("Correctly serializes json with scripts in it", function(){
 	});
 
 	var script = cloneAsset();
-	$("#qunit-test-area").append(script);
+	var icText = $(script).text();
+	var frame = $("#qunit-test-area").append("<iframe id='myframe'/>").find("#myframe");
+	frame.append("<script>" + icText + "</script>");
 
 	QUnit.ok(window.INLINE_CACHE, "Inline cache exists");
-	QUnit.ok(INLINE_CACHE["{\"foo\":\"bar\"}"], "The set key exists");
+	QUnit.ok(INLINE_CACHE["foo"], "The set key exists");
 });

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -32,6 +32,7 @@ test("Correctly serializes json with scripts in it", function(){
 
 	var map = new AppMap();
 	map.pageData("foo", {foo:"bar"}, {
+		"scripts": "just testing",
 		readme: "# hello world\n ```<script type=\"test/stache\">something</script>```"
 	});
 

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
 <title>can/map/app</title>
 <script src="../node_modules/steal/steal.js" main="test/app_test"></script>
 <div id="qunit-fixture"></div>
+<div id="qunit-test-area"></div>

--- a/test/tests/inline-cache/test.html
+++ b/test/tests/inline-cache/test.html
@@ -1,0 +1,3 @@
+<script>
+INLINE_CACHE = {"foo":{"{\"foo\":\"bar\"}":{"readme":"# hello world\n ```<script type=\"test/stache\">something</script>"}}};
+</script>


### PR DESCRIPTION
When browsers encounter something like:

```html
<script>
  INLINE_CACHE = {"thing": "<script src='foo.js'></script>"};
</script>
```

it will try to start importing the script, so we have to break it up to `"scr" + "ipt"` to make it work.