### PR TITLE
Make sure can/util/vdom can load

### DIFF
--- a/lib/system_config.js
+++ b/lib/system_config.js
@@ -7,6 +7,9 @@ var isNode = typeof process === "object" &&
 
 if(isNode) {
 	exports.systemConfig = {
+		map: {
+			"can/util/vdom/vdom": "can/util/vdom/vdom"
+		},
 		meta: {
 			'jquery': {
 				"format": "global",


### PR DESCRIPTION
The new version of Can now maps can/util/vdom/vdom to @empty by default,
	so if you are using an env other than server-development or
	server-production can-ssr can't load. To fix this we need to map
	can/util/vdom/vdom onto itself so that it definitely does load on
	the server no matter what env is set.