### PR TITLE
Allow live-reload

### DIFF
--- a/bin/can-serve
+++ b/bin/can-serve
@@ -13,15 +13,17 @@ program.version(pkg.version)
   .option('-p, --port <port>', 'The server port')
   .option('-r, --proxy <url>', 'A URL to an API that should be proxied')
   .option('-t, --proxy-to <path>', 'The path to proxy to (default: /api)')
+  .option('-l, --no-live-reload', 'Turn off live-reload')
   .parse(process.argv);
 
-var config = {
-  path: process.cwd()
+var options = {
+  path: process.cwd(),
+  liveReload: program.liveReload
 };
 
 if(program.proxy) {
-  config.proxy = program.proxy;
-  config.proxyTo = program.proxyTo;
+  options.proxy = program.proxy;
+  options.proxyTo = program.proxyTo;
 }
 
 // Spawn a child process in development mode
@@ -40,7 +42,7 @@ if(program.develop) {
 	}
 }
 
-var app = server(config);
+var app = server(options);
 var port = program.port || process.env.PORT || 3030;
 var server = app.listen(port);
 var address = server.address();

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,24 @@ module.exports = function(cfg){
 	// Ensure the extension is loaded before the main.
 	loadExtension(loader);
 
-	var startup = steal.startup().then(function(autorender){
+	function getAutorender(autorender){
 		// startup returns an Array in dev
 		autorender = Array.isArray(autorender) ? autorender[0] : autorender;
 		return autorender.importPromise || Promise.resolve(autorender);
+	}
+
+	var startup = steal.startup().then(function(autorender){
+		// If live-reload is enabled we need to get a new autorender each
+		// time a reload cycle is complete.
+		if(loader.has("live-reload")) {
+			var importOpts = {name: "steal-server-side-render"};
+			loader.import("live-reload", importOpts).then(function(reload){
+				reload(function(){
+					startup = loader.import(loader.main).then(getAutorender);
+				});
+			});
+		}
+		return getAutorender(autorender);
 	});
 
 	return function(url){

--- a/lib/load_extension.js
+++ b/lib/load_extension.js
@@ -26,9 +26,6 @@ function overrideConfig(loader){
 module.exports = function(loader){
 	// Configure the loader to set our overrides.
 	loader.config({
-		map: {
-			"live-reload": "@empty"
-		},
 		paths: {
 			"steal-server-side-render": "file:" + path.resolve(path.join(__dirname, "extension.js")),
 			"steal-server-side-render/system-config": "file:" + path.resolve(path.join(__dirname, "system_config.js"))

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -4,13 +4,14 @@ var url = require('url');
 var ssr = require('./index.js');
 var doctype = '<!DOCTYPE html>';
 
-module.exports = function(config) {
-	var pkgPath = path.join(config.path, 'package.json');
+module.exports = function(system, options) {
+	var pkgPath = path.join(options.path, 'package.json');
 	var pkg = require(pkgPath);
 
-	var system = {
-		config: pkgPath + '!npm'
-	};
+	// Default to using the npm plugin
+	if(!system.config) {
+		system.config = pkgPath + "!npm";
+	}
 
 	// In production we need to pass in the main, otherwise it doesn't know what
 	// bundle to load from.
@@ -24,7 +25,7 @@ module.exports = function(config) {
 		var pathname = url.parse(req.url).pathname;
 
 		render(pathname).then(function(result) {
-			var dt = config.doctype || doctype;
+			var dt = options.doctype || doctype;
 
 			res.html = dt + '\n' + result.html;
 			res.state = result.state;

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -5,28 +5,38 @@ var express = require('express');
 
 var middleware = require('../middleware');
 var xhr = require('./xhr');
+require('./websocket');
 var proxy = require('./proxy');
+var os = require('os');
 
-module.exports = function (config) {
+module.exports = function (options) {
 	var app = express()
 		.use(compression())
 		.use(xhr());
 
-	if (config.configure) {
-		config.configure(app);
+	if (options.configure) {
+		options.configure(app);
 	}
 
-	if (config.proxy) {
-		var apiPath = config.proxyTo || '/api';
+	if (options.proxy) {
+		var apiPath = options.proxyTo || '/api';
 		if(apiPath.charAt(0) !== '/') {
 			apiPath = '/' + apiPath;
 		}
 
-		app.use(apiPath, proxy(config.proxy));
+		app.use(apiPath, proxy(options.proxy));
 	}
 
-	app.use(express.static(path.join(config.path)))
-		.use(middleware(config))
+	var system = {
+		liveReload: options.liveReload,
+		liveReloadHost: os.hostname()
+	};
+	if(options.main) {
+		system.main = options.main;
+	}
+
+	app.use(express.static(path.join(options.path)))
+		.use(middleware(system, options))
 		.use(function(req, res) {
 			var status = res.state.attr('statusCode') || 200;
 

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -1,0 +1,31 @@
+var WebSocketClient = require('websocket').client;
+
+var MyWebSocket = global.WebSocket = function(address){
+	this.address = address;
+
+	// Create the connection here
+	this.client = new WebSocketClient();
+
+	var ws = this;
+	this.client.on('connect', function(connection){
+		ws.connection = connection;
+
+		ws.connection.on("message", function(data){
+			var msg = data.utf8Data;
+			if(ws.onmessage) {
+				ws.onmessage({
+					data: msg
+				});
+			}
+		});
+
+		if(ws.onopen) {
+			ws.onopen();
+		}
+	});
+	this.client.connect(this.address);
+};
+
+MyWebSocket.prototype.send = function(msg){
+	this.connection.send(msg);
+};

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "express": "^4.12.4",
     "http-proxy": "^1.11.1",
     "najax": "^0.1.5",
-    "steal": "^0.11.0-pre.8",
+    "steal": "^0.12.0-pre.0",
+    "websocket": "^1.0.21",
     "xmlhttprequest": "^1.7.0"
   },
   "system": {


### PR DESCRIPTION
This updates can-ssr to allow for live-reload. To make this work we are
now polyfilling the global.WebSocket constructor and providing a way to
configure the hostname used to connect to the live-reload server.

Import: this change is going to require Steal 0.12.0 to work. This is
because it includes changes to live-reload (and system-trace) that are
necessary for server side live-reload to work.

Fixes #14