### PR TITLE
Parse full URL (#52) and pass errors (#58)

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -22,7 +22,7 @@ module.exports = function(system, options) {
 	var render = ssr(system);
 
 	return function (req, res, next) {
-		var pathname = url.parse(req.url).pathname;
+		var pathname = url.parse(req.url).href;
 
 		render(pathname).then(function(result) {
 			var dt = options.doctype || doctype;
@@ -31,6 +31,6 @@ module.exports = function(system, options) {
 			res.state = result.state;
 
 			next();
-		});
+		}, next);
 	};
 };

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -56,4 +56,20 @@ describe('can-serve tests', function() {
 			done();
 		});
 	});
+
+	it('server should parse URL parameters (#52)', function(done) {
+		request('http://localhost:5050/test?param=paramtest', function(err, res, body) {
+			assert.equal(res.statusCode, 200);
+			assert.ok(/paramtest/.test(body), 'Param printed in body');
+			done();
+		});
+	});
+
+	it('errors when rendering an app trigger Express error handler (#58)',function(done) {
+		request('http://localhost:5050/?err=true', function(err, res, body) {
+			assert.equal(res.statusCode, 500);
+			assert.ok(/Something went wrong/.test(body), 'Got error message');
+			done();
+		});
+	});
 });

--- a/test/tests/progressive/appstate.js
+++ b/test/tests/progressive/appstate.js
@@ -1,3 +1,7 @@
 var AppMap = require("app-map");
 
-module.exports = AppMap.extend({});
+module.exports = AppMap.extend({
+	throwError: function() {
+		throw Error('Something went wrong');
+	}
+});

--- a/test/tests/progressive/index.stache
+++ b/test/tests/progressive/index.stache
@@ -25,6 +25,10 @@
 			<div>Error: {{statusMessage}}</div>
 		{{/eq}}
 
+		{{#if param}} {{param}} {{/if}}
+
+		{{#if err}} {{throwError}} {{/if}}
+
 		{{asset "inline-cache"}}
 	</body>
 </html>


### PR DESCRIPTION
Make sure that the server parses the full URL and pass application rendering errors to the Express error middleware.

Closes #52 and closes #58