### PR TITLE
Allow SSR to run before static file server.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -10,12 +10,12 @@ module.exports = function(system, options) {
 
 	// Default to using the npm plugin
 	if(!system.config) {
-		system.config = pkgPath + "!npm";
+		system.config = pkgPath + '!npm';
 	}
 
 	// In production we need to pass in the main, otherwise it doesn't know what
 	// bundle to load from.
-	if(process.env.NODE_ENV === "production") {
+	if(process.env.NODE_ENV === 'production') {
 		system.main = (pkg.system && pkg.system.main) || pkg.main;
 	}
 
@@ -24,14 +24,17 @@ module.exports = function(system, options) {
 	return function (req, res, next) {
 		var pathname = url.parse(req.url).href;
 
-		render(pathname).then(function(result) {
-			var dt = options.doctype || doctype;
-			var status = result.state.attr('statusCode') || 200;
-
-			res.status(status);
-			res.send(dt + '\n' + result.html);
-
+		// TODO: Check if pathname matches any configured endpoints. For now just the root.
+		if(pathname === '/'){
+			render(pathname).then(function(result) {
+				var dt = options.doctype || doctype;
+				var status = result.state.attr('statusCode') || 200;
+	
+				res.status(status);
+				return res.send(dt + '\n' + result.html);
+			});	
+		} else {
 			next();
-		}, next);
+		}
 	};
 };


### PR DESCRIPTION
This is hard-coded to watch for a root route "/" right now.  Is there a better option?