### PR TITLE
Set up middleware defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ app.use('/', ssr({
 }));
 ```
 
+The middleware includes a live-reload utility that can automatically refresh the cache for server-rendered responses. Use the `liveReload` option to enable this feature:
+
+```js
+app.use('/', ssr({
+  config: __dirname + '/public/package.json!npm',
+  liveReload: true
+}));
+```
+
 __Note:__ Make sure the ssr middleware is the last middleware in the chain but before the error handler. Errors when rendering the application will be passed to your Express error handler. Error status codes (e.g. 404s or others set via `appState.status()`) will be rendered with the application.
 
 ### Use Programatically

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -2,6 +2,7 @@ require('./websocket');
 
 var path = require('path');
 var url = require('url');
+var os = require('os');
 
 var ssr = require('./../index.js');
 var doctype = '<!DOCTYPE html>';
@@ -13,12 +14,16 @@ module.exports = function(system) {
 
 	// Default to using the npm plugin
 	if(!system.config) {
-		system.config = pkgPath + "!npm";
+		system.config = pkgPath + '!npm';
 	}
+	// liveReload is off by default.
+	system.liveReload = !!system.liveReload;
+	system.liveReloadAttempts = system.liveReloadAttempts || 3;
+	system.liveReloadHost = os.hostname();
 
 	// In production we need to pass in the main, otherwise it doesn't know what
 	// bundle to load from.
-	if(process.env.NODE_ENV === "production") {
+	if(process.env.NODE_ENV === 'production') {
 		system.main = (pkg.system && pkg.system.main) || pkg.main;
 	}
 
@@ -27,7 +32,7 @@ module.exports = function(system) {
 	return function (req, res, next) {
 		var pathname = url.parse(req.url).href;
 
-		XHR.base = req.protocol + "://" + req.get('host');
+		XHR.base = req.protocol + '://' + req.get('host');
 
 		render(pathname).then(function(result) {
 			var dt = system.doctype || doctype;

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -5,7 +5,6 @@ var express = require('express');
 
 var middleware = require('../middleware');
 var proxy = require('./proxy');
-var os = require('os');
 
 module.exports = function (options) {
 	var app = express()
@@ -24,19 +23,8 @@ module.exports = function (options) {
 		app.use(apiPath, proxy(options.proxy));
 	}
 
-	var system = {
-		config: path.join(options.path, 'package.json') + '!npm',
-		liveReload: options.liveReload,
-		liveReloadAttempts: 3,
-		liveReloadHost: os.hostname()
-	};
-
-	if(options.main) {
-		system.main = options.main;
-	}
-
 	app.use(express.static(path.join(options.path)))
-		.use(middleware(system));
+		.use(middleware({config: path.join(options.path, 'package.json') + '!npm', }));
 
 	return app;
 };


### PR DESCRIPTION
This adds defaults for the middleware to match the ones in server/index.js.  I've also updated the readme to explain how to turn `liveReload` on.  Closes #70 