### PR TITLE
After the main bundle has loaded treat all imports as possible bundles

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,12 +1,16 @@
 "format cjs";
 
 // Imports
+var steal = require("@steal");
 var loader = require("@loader");
 var stache = require("can/view/stache/stache");
 require("can/view/import/import");
 
 var bundles = {"@global": {}};
 var parentMap = {};
+var mainBundleLoaded = false;
+var mightBeABundle = {};
+steal.done().then(function() { mainBundleLoaded = true; });
 
 function setAsBundle(name, parentName){
 	return loader.normalize(name, parentName).then(function(name) {
@@ -135,6 +139,7 @@ var loaderImport = loader.import;
 loader.import = function(name, options){
 	var loader = this, args = arguments;
 	var parentName = options ? options.name : undefined;
+
 	return setAsBundle(name, parentName).then(function(){
 		return loaderImport.apply(loader, args);
 	});
@@ -145,7 +150,10 @@ loader.normalize = function(name, parentName){
 	var promise = Promise.resolve(normalize.apply(this, arguments));
 
 	return promise.then(function(normalizedName){
-		if(parentName) {
+		// When the main bundle loads we mark all can-imports as mightBeABundle
+		if(mightBeABundle[name] && !parentMap[normalizedName]) {
+			parentMap[normalizedName] = false;
+		} else if(parentName) {
 			parentMap[normalizedName] = parentName;
 		}
 		return normalizedName;
@@ -158,6 +166,11 @@ can.view.callbacks._tags["can-import"] = function(el, tagData){
 	var moduleName = el.getAttribute("from");
 	var templateModule = tagData.options.attr("helpers.module");
 	var parentName = templateModule ? templateModule.id : undefined;
+
+	// If the main is loaded them any imports might be a bundle.
+	if(mainBundleLoaded) {
+		mightBeABundle[moduleName] = true;
+	}
 
 	// Override waitFor temporarily.
 	var waitFor = root.waitFor;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -16,3 +16,14 @@ exports.traverse = function(node, callback){
 		cur = cur.nextSibling;
 	}
 };
+
+exports.count = function(node, callback){
+	var count = 0;
+	exports.traverse(node, function(){
+		var truthy = callback.apply(this, arguments);
+		if(truthy) {
+			count++;
+		}
+	});
+	return count;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,30 @@ describe("rendering an app", function(){
 		}).then(done);
 	});
 
+	it("returns only the css needed for the request", function(done){
+		var render = this.render;
+
+		var checkCount = function(result, expected, message){
+			var node = helpers.dom(result.html);
+
+			var styles = helpers.count(node, function(el){
+				return el.nodeName === "STYLE";
+			});
+
+			assert.equal(styles, expected, message);
+		};
+
+		render("/orders").then(function(result){
+			checkCount(result, 2, "There should be 2 styles for the orders page");
+
+			return render("/");
+		}).then(function(result){
+			checkCount(result, 1, "There should only be 1 style for the root page");
+
+			done();
+		});
+	});
+
 	it("sets status to 404 if route was not round", function(done){
 		this.render("/invalid/route").then(function(result){
 			var state = result.state;

--- a/test/tests/progressive/orders/orders.stache
+++ b/test/tests/progressive/orders/orders.stache
@@ -1,5 +1,5 @@
 <div id="orders">
 {{#each orders}}
-	<div>order {{@index}}</div>
+	<div>order {{%index}}</div>
 {{/each}}
 </div>


### PR DESCRIPTION
This fixes #74

It's hard to know when an import is a "page". We need to know this so
that our parentMap stops when you get to a page. This is essential to
making sure only the right css is returned for each request.

The fix (not perfect) is to wait until `steal.done()` and from this
point treat all imports as possibly being a bundle. If they don't have
an entry in the parent map (meaning they haven't been loaded yet) we
know they are probably a parent bundle.