### PR TITLE
Make can-serve --develop work on Windows

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,7 +16,7 @@
 	"eqeqeq": true,
 	"freeze": true,
 	"indent": 2,
-	"latedef": true,
+	"latedef": false,
 	"noarg": true,
 	"undef": true,
 	"unused": "vars",

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var fs = require('fs');
+var path = require("path");
 var program = require('commander');
 
 var pkg = require('../package.json');
@@ -14,6 +15,7 @@ program.version(pkg.version)
   .option('-r, --proxy <url>', 'A URL to an API that should be proxied')
   .option('-t, --proxy-to <path>', 'The path to proxy to (default: /api)')
   .option('-l, --no-live-reload', 'Turn off live-reload')
+  .option('--steal-tools-path <path>', 'Location of your steal-tools')
   .parse(process.argv);
 
 var options = {
@@ -28,12 +30,14 @@ if(program.proxy) {
 
 // Spawn a child process in development mode
 if(program.develop) {
-	if(!fs.existsSync('node_modules/.bin/steal-tools')) {
+	var stealToolsPath = program.stealToolsPath ||
+		path.join("node_modules", ".bin", "steal-tools");
+	if(!fs.existsSync(stealToolsPath)) {
 		console.error('live-reload not available: ' +
 			'No local steal-tools binary found. ' +
 			'Run `npm install steal-tools --save-dev`.');
 	} else {
-		var child = exec('node_modules/.bin/steal-tools live-reload', {
+		var child = exec(stealToolsPath + ' live-reload', {
 			cwd: process.cwd()
 		});
 

--- a/bin/can-serve.cmd
+++ b/bin/can-serve.cmd
@@ -1,0 +1,7 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\can-serve" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\can-serve" %*
+)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 30000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",
@@ -43,6 +43,7 @@
     "jshint": "^2.8.0",
     "mocha": "^2.2.4",
     "request": "^2.61.0",
+    "steal-tools": "^0.12.0-pre.0",
     "steal-qunit": "0.0.4",
     "testee": "^0.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 30000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/test/can-serve_test.js
+++ b/test/can-serve_test.js
@@ -1,0 +1,54 @@
+var assert = require("assert");
+var path = require("path");
+var spawn = require("child_process").spawn;
+
+describe("can-serve cli tests", function(){
+	this.timeout(30000);
+
+	var canServeBin = path.join(__dirname, "..", "bin", "can-serve");
+	var stealToolsBin = path.join(__dirname, "..", "node_modules",
+								  "steal-tools", "bin", "steal");
+
+	describe("--develop", function(){
+		beforeEach(function(){
+			this.pwd = process.cwd();
+			process.chdir(path.join(__dirname, "tests"));
+		});
+
+		afterEach(function(){
+			process.chdir(this.pwd);
+		});
+
+		it("starts up web and live-reload servers", function(done){
+			var child = spawn(canServeBin, [
+				"--develop",
+				"--steal-tools-path",
+				stealToolsBin,
+				"--port",
+				"8085"
+			]);
+			// Keeps track of the web server and live-reload server starting.
+			var partsStarted = 0;
+
+			child.stdout.setEncoding("utf8");
+
+			child.stdout.on("data", checkMessage);
+			child.stderr.on("data", checkMessage);
+
+			function checkMessage(msg){
+				if(/can-serve starting/.test(msg)) {
+					assert(true, "web server started");
+					partsStarted++;
+				}
+				if(/Live-reload server/.test(msg)) {
+					assert(true, "live-reload started");
+					partsStarted++;
+				}
+				if(partsStarted === 2) {
+					child.kill();
+					done();
+				}
+			}
+		});
+	});
+});

--- a/test/can-serve_test.js
+++ b/test/can-serve_test.js
@@ -5,9 +5,14 @@ var spawn = require("child_process").spawn;
 describe("can-serve cli tests", function(){
 	this.timeout(30000);
 
-	var canServeBin = path.join(__dirname, "..", "bin", "can-serve");
-	var stealToolsBin = path.join(__dirname, "..", "node_modules",
-								  "steal-tools", "bin", "steal");
+	var isWin = /^win/.test(process.platform);
+	var platformExt = function(p) {
+		return p + (isWin ? ".cmd" : "");
+	};
+
+	var canServeBin = platformExt(path.join(__dirname, "..", "bin", "can-serve"));
+	var stealToolsBin = platformExt(path.join(__dirname, "..", "node_modules",
+								  ".bin", "steal-tools"));
 
 	describe("--develop", function(){
 		beforeEach(function(){
@@ -27,6 +32,7 @@ describe("can-serve cli tests", function(){
 				"--port",
 				"8085"
 			]);
+
 			// Keeps track of the web server and live-reload server starting.
 			var partsStarted = 0;
 


### PR DESCRIPTION
Using path.join to find the path to the steal-tools binary rather than
expecting a unix path. Fixes #77