### PR TITLE
Implements new Main Module API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,11 @@ module.exports = function(grunt){
 					src:["node_modules/done-autorender/**"],
 					dest: "test/tests/",
 					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/can-wait/**"],
+					dest: "test/tests/node_modules/done-autorender/",
+					filter: "isFile"
 				}]
 			}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,8 +26,43 @@ module.exports = function(grunt){
 					dest: "test/tests/node_modules/done-autorender/",
 					filter: "isFile"
 				}]
+			},
+			toReact: {
+				files: [{
+					expand: true,
+					src:["node_modules/can/**"],
+					dest: "test/tests/react/",
+					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/jquery/**"],
+					dest: "test/tests/react/",
+					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/react/**"],
+					dest: "test/tests/react/",
+					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/react-dom/**"],
+					dest: "test/tests/react/",
+					filter: "isFile"
+				}]
+			},
+			tojQuery: {
+				files: [{
+					expand: true,
+					src:["node_modules/can/**"],
+					dest: "test/tests/jquery/",
+					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/jquery/**"],
+					dest: "test/tests/jquery/",
+					filter: "isFile"
+				}]
 			}
-
 		}
 	});
 

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,16 +1,12 @@
 "format cjs";
 
 // Imports
-var steal = require("@steal");
 var loader = require("@loader");
 var stache = require("can/view/stache/stache");
 require("can/view/import/import");
 
 var bundles = {"@global": {}};
 var parentMap = {};
-var mainBundleLoaded = false;
-var mightBeABundle = {};
-steal.done().then(function() { mainBundleLoaded = true; });
 
 function setAsBundle(name, parentName){
 	return loader.normalize(name, parentName).then(function(name) {
@@ -150,10 +146,7 @@ loader.normalize = function(name, parentName){
 	var promise = Promise.resolve(normalize.apply(this, arguments));
 
 	return promise.then(function(normalizedName){
-		// When the main bundle loads we mark all can-imports as mightBeABundle
-		if(mightBeABundle[name] && !parentMap[normalizedName]) {
-			parentMap[normalizedName] = false;
-		} else if(parentName) {
+		if(parentName && parentMap[normalizedName] !== false) {
 			parentMap[normalizedName] = parentName;
 		}
 		return normalizedName;
@@ -167,30 +160,15 @@ can.view.callbacks._tags["can-import"] = function(el, tagData){
 	var templateModule = tagData.options.attr("helpers.module");
 	var parentName = templateModule ? templateModule.id : undefined;
 
-	// If the main is loaded them any imports might be a bundle.
-	if(mainBundleLoaded) {
-		mightBeABundle[moduleName] = true;
-	}
-
-	// Override waitFor temporarily.
-	var waitFor = root.waitFor;
-	root.waitFor = function(dfd){
-		dfd = dfd.then(function(val){
-			var newDfd = new can.Deferred();
-
-			loader.normalize(moduleName, parentName).then(function(name){
-				root.attr("__renderingAssets").push(name);
-				newDfd.resolve(val);
-			});
-
-			return newDfd;
-		});
-		waitFor.call(this, dfd);
-	};
+	var isAPage = !!tagData.subtemplate;
+	loader.normalize(moduleName, parentName).then(function(name){
+		if(isAPage) {
+			parentMap[name] = false;
+		}
+		root.attr("__renderingAssets").push(name);
+	});
 
 	canImport.apply(this, arguments);
-
-	root.waitFor = waitFor;
 };
 
 [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var Steal = require("steal");
 var loadExtension = require("./load_extension");
 var trigger = require("./trigger");
+var makeMap = require("./make_map");
 
 module.exports = function(cfg){
 	var steal = Steal.clone();
@@ -38,38 +39,59 @@ module.exports = function(cfg){
 
 	return function(url){
 		return startup.then(function(autorender){
+			var serializeFromBody = autorender.renderAsync || autorender.serializeFromBody;
 			var doc = new document.constructor();
-			var ViewModel = autorender.viewModel;
-
-			if(!ViewModel) {
-				throw new Error("can-ssr cannot render your application without a viewModel defined. " +
-								"See the guide for information. " +
-								"http://donejs.com/Guide.html#section_Createatemplateandmainfile");
+			if(!serializeFromBody) {
+				doc.head = doc.createElement("head");
+				doc.documentElement.insertBefore(doc.head, doc.body);
 			}
 
-			var state = new ViewModel();
-			var params = can.route.deparam(url);
+			// New API is createState, if not fall back to the old API
+			var createState = autorender.createState || function(request){
+				var ViewModel = autorender.viewModel;
 
-			state.attr(params);
-			state.attr("__renderingAssets", []);
-			state.attr("env", process.env);
-
-			if(typeof state.pageStatus === 'function' &&
-					!state.attr('statusCode') &&
-					!can.isEmptyObject(can.route.routes)) {
-				if(!params.route) {
-					state.pageStatus(404, 'Not found');
-				} else {
-					state.pageStatus(200);
+				if(!ViewModel) {
+					throw new Error("can-ssr cannot render your application " +
+									"without a viewModel defined. " +
+									"See the guide for information. " +
+									"http://donejs.com/Guide.html#section_Createatemplateandmainfile");
 				}
-			}
 
-			var render = autorender.render;
-			return autorender.renderAsync(render, state, {}, doc)
+				var state = new ViewModel();
+				var params = can.route.deparam(url);
+
+				state.attr(params);
+				state.attr("__renderingAssets", []);
+				state.attr("env", process.env);
+
+				if(typeof state.pageStatus === 'function' &&
+						!state.attr('statusCode') &&
+						!can.isEmptyObject(can.route.routes)) {
+					if(!params.route) {
+						state.pageStatus(404, 'Not found');
+					} else {
+						state.pageStatus(200);
+					}
+				}
+				return state;
+			};
+
+			var state = createState({ url: url });
+			var stateMap = makeMap(state);
+
+			// Support both the legacy autorender API and the new API
+			// specified by https://github.com/canjs/can-ssr/issues/80
+			var render = !autorender.renderAsync ? autorender.render : function(){
+				var render = autorender.render;
+				return autorender.renderAsync(render, state, {}, doc);
+			};
+
+			return Promise.resolve(render(doc, state))
 				.then(function(){
-					state.attr("__renderingComplete", true);
+					stateMap.attr("__renderingComplete", true);
 				}).then(function() {
-					var html = doc.body.innerHTML;
+					var html = serializeFromBody ? doc.body.innerHTML :
+						doc.documentElement.outerHTML;
 
 					// Cleanup the dom
 					trigger(doc, "removed");

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,10 @@
+/*global canWait:false */
 var Steal = require("steal");
 var loadExtension = require("./load_extension");
 var trigger = require("./trigger");
 var makeMap = require("./make_map");
+var mergeResponseData = require("./merge_response_data");
+var wait = require("can-wait");
 
 module.exports = function(cfg){
 	var steal = Steal.clone();
@@ -39,7 +42,8 @@ module.exports = function(cfg){
 
 	return function(url){
 		return startup.then(function(autorender){
-			var serializeFromBody = autorender.renderAsync || autorender.serializeFromBody;
+			var serializeFromBody = !!(autorender.renderAsync ||
+									   autorender.serializeFromBody);
 			var doc = new document.constructor();
 			if(!serializeFromBody) {
 				doc.head = doc.createElement("head");
@@ -74,24 +78,53 @@ module.exports = function(cfg){
 					}
 				}
 				return state;
-			};
 
-			var state = createState({ url: url });
-			var stateMap = makeMap(state);
+			};
 
 			// Support both the legacy autorender API and the new API
 			// specified by https://github.com/canjs/can-ssr/issues/80
-			var render = !autorender.renderAsync ? autorender.render : function(){
+			var useLegacyAPI = autorender.legacy !== false &&
+				autorender.renderAsync;
+			var render = !useLegacyAPI ? autorender.render.bind(autorender) :
+				function(){
 				var render = autorender.render;
-				return autorender.renderAsync(render, state, {}, doc);
+				return autorender.renderAsync(render, state, {}, doc)
+					.then(function(result){
+						(result.canWaitData || []).forEach(function(data){
+							canWait.data(data);
+						});
+					}, function(err){
+						throw err;
+					});
 			};
 
-			return Promise.resolve(render(doc, state))
+			var state, stateMap;
+			var run = function(){
+				state = createState({ url: url });
+				stateMap = makeMap(state);
+
+				Promise.resolve(render(doc, state)).then(null, function(errors){
+					(errors || []).forEach(function(error){
+						canWait.error(error);
+					});
+				});
+			};
+
+			return wait(run)
+			//return Promise.resolve(render(doc, state))
+				.then(function(resp){
+					mergeResponseData(stateMap, resp);
+				})
 				.then(function(){
 					stateMap.attr("__renderingComplete", true);
-				}).then(function() {
-					var html = serializeFromBody ? doc.body.innerHTML :
-						doc.documentElement.outerHTML;
+				})
+				.then(function() {
+					var html;
+					if(serializeFromBody) {
+						html = doc.body.innerHTML;
+					} else {
+						html = doc.documentElement.outerHTML;
+					}
 
 					// Cleanup the dom
 					trigger(doc, "removed");

--- a/lib/load_extension.js
+++ b/lib/load_extension.js
@@ -1,5 +1,10 @@
 var path = require("path");
 var aliasNpm = require("./alias_npm");
+var pkg = require("../package.json");
+
+global.navigator = global.navigator || {
+	userAgent: "Mozilla/5.0 " + "can-ssr/" + pkg.version
+};
 
 // Override config to prevent the baseURL from being set to something that
 // can't be used to render.

--- a/lib/make_map.js
+++ b/lib/make_map.js
@@ -1,0 +1,41 @@
+module.exports = makeMap;
+
+function makeMap(instance){
+	if(looksLikeAMap(instance)) {
+		return instance;
+	}
+
+	return {
+		attr: function(key, value){
+			if(!value && typeof key !== "object") {
+				return instance[key];
+			} else {
+				return setState(instance, key, value);
+			}
+		}
+	};
+}
+
+function looksLikeAMap(instance) {
+	return !!(instance.attr && instance.bind);
+}
+
+function setState(instance, key, value) {
+	if(looksLikeAMap(instance)) {
+		// It's an object
+		if(!value) {
+			instance.attr(key);
+		} else {
+			instance.attr(key, value);
+		}
+	} else {
+		if(!value) {
+			Object.keys(key).forEach(function(k){
+				instance[k] = key[k];
+			});
+		} else {
+			instance[key] = value;
+		}
+	}
+}
+

--- a/lib/merge_response_data.js
+++ b/lib/merge_response_data.js
@@ -1,0 +1,10 @@
+
+module.exports = function(state, responses){
+	responses = responses || [];
+	var pageData = state.__pageData = state.__pageData || {};
+	responses.forEach(function(resp){
+		if(resp.pageData) {
+			can.extend(pageData, resp.pageData);
+		}
+	});
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test --timeout 10000 && && mocha test/jquery_test --timeout 10000 mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test --timeout 10000 && && mocha test/jquery_test --timeout 10000 mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js && mocha test/react_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",
@@ -45,7 +45,9 @@
     "request": "^2.61.0",
     "steal-qunit": "0.0.4",
     "steal-tools": "^0.12.0-pre.0",
-    "testee": "^0.2.0"
+    "testee": "^0.2.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "dependencies": {
     "can": "^2.3.0-pre || ^2.3.0-beta || ^2.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout && mocha test/react_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout 10000 && mocha test/react_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js && mocha test/react_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout && mocha test/react_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "can": "^2.3.0-pre || ^2.3.0-beta || ^2.3.0",
+    "can-wait": "^0.2.0",
     "commander": "^2.8.1",
     "compression": "^1.4.4",
     "express": "^4.12.4",

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -1,0 +1,31 @@
+var canSsr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+
+describe("async rendering", function(){
+	before(function(){
+		this.render = canSsr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "async/index.stache!done-autorender",
+			paths: {
+				"$css": "file:" + path.resolve(__dirname + "/tests/less_plugin.js")
+			}
+		});
+	});
+
+	it("basics works", function(done){
+		this.render("/").then(function(result){
+			var node = helpers.dom(result.html);
+
+			var message = node.getElementById("orders");
+
+			assert(message, "Found the message element that was rendered" +
+				   "asynchronously");
+
+			var cache = helpers.getInlineCache(node);
+
+			assert(cache.restaurant, "restaurant key was added");
+		}).then(done, done);
+	});
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,6 +17,36 @@ exports.traverse = function(node, callback){
 	}
 };
 
+exports.find = function(node, callback){
+	var out;
+	exports.traverse(node, function(el){
+		if(callback(el)) {
+			out = el;
+		}
+	});
+	return out;
+};
+
+exports.text = function(node){
+	var txt = "";
+	exports.traverse(node, function(el){
+		if(el.nodeType === 3) {
+			txt += el.nodeValue;
+		}
+	});
+	return txt;
+};
+
+exports.getInlineCache = function(node){
+	var script = exports.text(exports.find(node, function(el){
+		return el.getAttribute && el.getAttribute("asset-id") === "@inline-cache";
+	})).trim().replace(/INLINE_CACHE = /, "");
+	var cache = JSON.parse(
+		script.substr(0, script.length - 1)
+	);
+	return cache;
+};
+
 exports.count = function(node, callback){
 	var count = 0;
 	exports.traverse(node, function(){

--- a/test/jquery_test.js
+++ b/test/jquery_test.js
@@ -1,0 +1,32 @@
+var canSsr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+
+describe("rendering a jquery app", function(){
+	before(function(){
+		this.render = canSsr({
+			config: "file:" + path.join(__dirname, "tests/jquery", "package.json!npm"),
+			paths: {
+				"$css": "file:" + path.resolve(__dirname + "/tests/less_plugin.js")
+			}
+		});
+	});
+
+	it("works asynchronously", function(done){
+		this.render("/").then(function(result){
+			var node = helpers.dom(result.html);
+
+			var app = node.getElementById("app");
+			assert(app, "the #app rendered");
+
+			var present = app.firstChild,
+				future = present.nextSibling;
+			assert.equal(helpers.text(present).trim(),
+						 "Hello from the present");
+
+			assert.equal(helpers.text(future).trim(),
+						 "Hello from the future");
+		}).then(done, done);
+	});
+});

--- a/test/react_test.js
+++ b/test/react_test.js
@@ -1,0 +1,30 @@
+var canSsr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+
+describe("rendering a React app", function(){
+	before(function(){
+		this.render = canSsr({
+			config: "file:" + path.join(__dirname, "tests/react",
+										"package.json!npm")
+		});
+	});
+
+	it("works asynchronously", function(done){
+		this.render("/").then(function(result){
+			var node = helpers.dom(result.html);
+
+			var app = node.getElementById("main");
+			assert(app, "the #main rendered");
+
+			var present = app.firstChild,
+				future = present.nextSibling;
+			assert.equal(helpers.text(present).trim(),
+						 "Hello from the present");
+
+			assert.equal(helpers.text(future).trim(),
+						 "Hello from the future");
+		}).then(done, done);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,8 @@ describe("rendering an app", function(){
 				return el.nodeName === "STYLE";
 			});
 
-			assert.equal(styles, expected, message);
+			assert.equal(styles, expected, message + " | " + styles +
+						 " !== " + expected);
 		};
 
 		render("/orders").then(function(result){

--- a/test/tests/async/appstate.js
+++ b/test/tests/async/appstate.js
@@ -1,0 +1,22 @@
+var AppMap = require("app-map");
+require("can/map/define/");
+
+module.exports = AppMap.extend({
+	define: {
+		page: {
+			set: function(val){
+				if(val === "home") {
+					var state = this;
+					setTimeout(function(){
+						state.attr("message", "hello async!");
+					}, 300);
+				}
+
+				return val;
+			}
+		},
+		message: {
+			type: "string"
+		}
+	}
+});

--- a/test/tests/async/index.stache
+++ b/test/tests/async/index.stache
@@ -1,0 +1,26 @@
+<html>
+	<head>
+		<title>test page</title>
+
+		{{asset "css"}}
+		{{asset "html5shiv"}}
+	</head>
+	<body>
+		<can-import from="async/routes"/>
+		<can-import from="async/appstate" as="viewModel" />
+
+		{{#eq page "orders"}}
+			<can-import from="async/orders/">
+				{{#isResolved}}
+					<order-history></order-history>
+				{{/isResolved}}
+			</can-import>
+
+			{{#if message}}
+				<div id="message">{{message}}</div>
+			{{/if}}
+		{{/eq}}
+
+		{{asset "inline-cache"}}
+	</body>
+</html>

--- a/test/tests/async/orders/orders.css
+++ b/test/tests/async/orders/orders.css
@@ -1,0 +1,3 @@
+order-history {
+	background: blue;
+}

--- a/test/tests/async/orders/orders.js
+++ b/test/tests/async/orders/orders.js
@@ -1,0 +1,36 @@
+var can = require("can");
+var template = require("./orders.stache!");
+require("./orders.css!");
+require("can/map/define/");
+
+var ViewModel = can.Map.extend({
+	define: {
+		orders: {
+			Value: can.List,
+			get: function(list){
+				var id = "foo";
+				var dfd = new can.Deferred();
+				canWait.data(dfd.then(function(resp){
+					return {
+						pageData: {
+							restaurant: {
+								"{\"foo\":\"foo\"}": resp
+							}
+						}
+					};
+				}));
+
+				list.replace(dfd);
+				dfd.resolve([ { a: "a" }, { b: "b" } ]);
+
+				return list;
+			}
+		}
+	}
+});
+
+can.Component.extend({
+	tag: "order-history",
+	template: template,
+	viewModel: ViewModel
+});

--- a/test/tests/async/orders/orders.stache
+++ b/test/tests/async/orders/orders.stache
@@ -1,0 +1,5 @@
+<div id="orders">
+{{#each orders}}
+	<div>order {{%index}}</div>
+{{/each}}
+</div>

--- a/test/tests/async/routes.js
+++ b/test/tests/async/routes.js
@@ -1,0 +1,4 @@
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+route(":page", { page: "orders" });

--- a/test/tests/jquery/index.js
+++ b/test/tests/jquery/index.js
@@ -6,6 +6,12 @@ exports.createState = function(){
 
 exports.render = function(document){
 	$("<title>").text("jQuery App").appendTo(document.head);
-	var div = $("<div>").attr("id", "app").text("Hello world");
-	$(document.body).append(div);
+
+	var app = $("<div>").attr("id", "app");
+	$("<div>").text("Hello from the present").appendTo(app);
+	$(document.body).append(app);
+
+	setTimeout(function(){
+		$("<div>").text("Hello from the future").appendTo(app);
+	}, 200);
 };

--- a/test/tests/jquery/index.js
+++ b/test/tests/jquery/index.js
@@ -1,0 +1,11 @@
+var $ = require("jquery");
+
+exports.createState = function(){
+	return {};
+};
+
+exports.render = function(document){
+	$("<title>").text("jQuery App").appendTo(document.head);
+	var div = $("<div>").attr("id", "app").text("Hello world");
+	$(document.body).append(div);
+};

--- a/test/tests/jquery/package.json
+++ b/test/tests/jquery/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "can": "^2.3.0-beta.0",
+    "can": "^2.3.0",
     "jquery": "^2.1.4"
   }
 }

--- a/test/tests/jquery/package.json
+++ b/test/tests/jquery/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "jquery-app",
+  "version": "1.0.0",
+  "description": "This is a jQuery app",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "can": "^2.3.0-beta.0",
+    "jquery": "^2.1.4"
+  }
+}

--- a/test/tests/jquery/render.js
+++ b/test/tests/jquery/render.js
@@ -1,8 +1,6 @@
 var ssr = require("../../../lib");
 
-var render = ssr({
-	config: __dirname + "/package.json!npm"
-});
+var render = ssr();
 
 render("/").then(function(result){
 	console.log(result.html);

--- a/test/tests/jquery/render.js
+++ b/test/tests/jquery/render.js
@@ -1,0 +1,9 @@
+var ssr = require("../../../lib");
+
+var render = ssr({
+	config: __dirname + "/package.json!npm"
+});
+
+render("/").then(function(result){
+	console.log(result.html);
+});

--- a/test/tests/react/index.html
+++ b/test/tests/react/index.html
@@ -1,0 +1,2 @@
+<script src="../../../node_modules/steal/steal.js"
+	config="./package.json!npm"></script>

--- a/test/tests/react/index.js
+++ b/test/tests/react/index.js
@@ -1,0 +1,18 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+let HelloMessage = React.createClass({
+  render: function() {
+    return <div>Hello {this.props.name}!</div>;
+  }
+});
+
+export function createState() {
+	return {};
+}
+
+export function render(document){
+	var div = document.createElement("div");
+	document.body.appendChild(div);
+	ReactDOM.render(<HelloMessage name="World" />, div);
+}

--- a/test/tests/react/index.js
+++ b/test/tests/react/index.js
@@ -1,10 +1,36 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
-let HelloMessage = React.createClass({
+let FutureMessage = React.createClass({
+	getInitialState: function(){
+		var component = this;
+		setTimeout(function(){
+			component.setState({ msg: "Hello from the future" });
+		}, 200);
+
+		return {
+			msg: ""
+		};
+	},
+
+	render: function(){
+		return <div id="future">{this.state.msg}</div>
+	}
+});
+
+let PresentMessage = React.createClass({
   render: function() {
-    return <div>Hello {this.props.name}!</div>;
+    return <div id="present">Hello from the present</div>;
   }
+});
+
+let Main = React.createClass({
+	render: function() {
+		return (<div id="main">
+			<PresentMessage />
+			<FutureMessage />
+		</div>);
+	}
 });
 
 export function createState() {
@@ -14,5 +40,12 @@ export function createState() {
 export function render(document){
 	var div = document.createElement("div");
 	document.body.appendChild(div);
-	ReactDOM.render(<HelloMessage name="World" />, div);
+	ReactDOM.render(<Main />, div);
+}
+
+var isNode = typeof process === "object" && {}.toString.call(process) ===
+	"[object process]";
+
+if(!isNode) {
+	render(document);
 }

--- a/test/tests/react/package.json
+++ b/test/tests/react/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "react-app",
+  "version": "1.0.0",
+  "description": "This is a jQuery app",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "can": "^2.3.0-beta.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
+  },
+  "system": {
+    "transpiler": "babel",
+    "babelOptions": {
+      "blacklist": []
+    }
+  }
+}

--- a/test/tests/react/package.json
+++ b/test/tests/react/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "can": "^2.3.0-beta.0",
+    "can": "^2.3.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },

--- a/test/tests/react/render.js
+++ b/test/tests/react/render.js
@@ -1,0 +1,9 @@
+var ssr = require("../../../lib");
+
+var render = ssr({
+	config: __dirname + "/package.json!npm"
+});
+
+render("/").then(function(result){
+	console.log(result.html);
+});


### PR DESCRIPTION
This commit implements the Main Module API as defined in #80. What this
means is that you can use can-ssr with any JavaScript module as long as
they implement these two APIs:

Creates an Object that will hold state relevant for the request. This
could be some type of typed object that acts as a view model for your
app or it could be a plain object, depending on what your framework
needs.

```js
exports.createState = function(){
	return new AppViewModel();
};
```

**render** is a function that returns a Promise when it has finished
rendering. It is given a new Document that it can write to, or it could
also return a string representation.

```js
exports.render = function(doc, state){
	var $body = $(doc.body);

	$body.append($("<div>Hello world</div>"));

	return $.getJSON("/some/data.json").then(function(data){
		// render the data some how
	});
};
```

If writing directly to the provided Document can-ssr will stringify the
documentElement and return that as the response.

Closes #80 and #84 