### PR TITLE
Implements the plugin API

### DIFF
--- a/lib/bundles.js
+++ b/lib/bundles.js
@@ -1,0 +1,35 @@
+// Imports
+var loader = require("@loader");
+
+// Exports
+exports.setAsBundle = setAsBundle;
+exports.findBundle = findBundle;
+
+var bundles = exports.bundles = {"@global": {}};
+var parentMap = exports.parentMap = {};
+
+function setAsBundle(name, parentName){
+	return loader.normalize(name, parentName).then(function(name) {
+		if(!bundles[name]) {
+			bundles[name] = {};
+		}
+	});
+}
+
+function findBundleName(moduleName) {
+	var parent = parentMap[moduleName],
+		bundleName = parent;
+	while(parent) {
+		parent = parentMap[parent];
+		if(parent) {
+			bundleName = parent;
+		}
+	}
+	return bundleName;
+}
+
+function findBundle(moduleName){
+	var bundleName = findBundleName(moduleName);
+	return bundles[bundleName];
+}
+

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -2,85 +2,14 @@
 
 // Imports
 var loader = require("@loader");
-var stache = require("can/view/stache/stache");
-require("can/view/import/import");
+var helpers = require("@ssr/bundles");
 
-var bundles = {"@global": {}};
-var parentMap = {};
-
-function setAsBundle(name, parentName){
-	return loader.normalize(name, parentName).then(function(name) {
-		if(!bundles[name]) {
-			bundles[name] = {};
-		}
-	});
-}
-
-function isProduction(options){
-	var prod = process.env.NODE_ENV === "production";
-	if(prod) {
-		return options.fn(this);
-	} else {
-		return options.inverse(this);
-	}
-}
-
-function findBundleName(moduleName) {
-	var parent = parentMap[moduleName],
-		bundleName = parent;
-	while(parent) {
-		parent = parentMap[parent];
-		if(parent) {
-			bundleName = parent;
-		}
-	}
-	return bundleName;
-}
-
-function findBundle(moduleName){
-	var bundleName = findBundleName(moduleName);
-	return bundles[bundleName];
-}
-
-function assetHelper(type){
-	var state = this;
-	var assets = this.attr("__renderingAssets");
-	var complete = this.attr("__renderingComplete");
-	var frag = document.createDocumentFragment();
-
-	if(complete) {
-		var inserted = {};
-		assets.each(function(moduleName){
-			var bundle = findBundle(moduleName) || bundles[moduleName];
-
-			if(bundle) {
-				Object.keys(bundle).forEach(function(childName){
-					var asset = bundle[childName];
-					if(asset && asset.type === type && !inserted[asset.id]) {
-						inserted[asset.id] = true;
-						var node = asset.value.call(state);
-						node.setAttribute("asset-id", asset.id);
-						frag.appendChild(node);
-					}
-				});
-			}
-		});
-
-		var globals = bundles["@global"];
-		Object.keys(globals).forEach(function(moduleName){
-			var asset = globals[moduleName];
-			if(asset.type === type) {
-				var node = asset.value.call(state);
-				if(node.setAttribute) {
-					node.setAttribute("asset-id", "@" + asset.type);
-				}
-				frag.appendChild(node);
-			}
-		});
-	}
-
-	return frag;
-}
+// Bundle helpers
+var setAsBundle = helpers.setAsBundle;
+var findBundle = helpers.findBundle;
+var findBundleName = helpers.findBundleName;
+var bundles = helpers.bundles;
+var parentMap = helpers.parentMap;
 
 function assetRegister(moduleName, type, makeAsset) {
 	if(arguments.length === 2) {
@@ -128,9 +57,6 @@ loader.set("asset-register", loader.newModule({
 	"default": assetRegister
 }));
 
-stache.registerHelper("asset", assetHelper);
-stache.registerHelper("isProduction", isProduction);
-
 var loaderImport = loader.import;
 loader.import = function(name, options){
 	var loader = this, args = arguments;
@@ -151,24 +77,6 @@ loader.normalize = function(name, parentName){
 		}
 		return normalizedName;
 	});
-};
-
-var canImport = can.view.callbacks._tags["can-import"];
-can.view.callbacks._tags["can-import"] = function(el, tagData){
-	var root = tagData.scope.attr("%root") || tagData.scope.attr("@root");
-	var moduleName = el.getAttribute("from");
-	var templateModule = tagData.options.attr("helpers.module");
-	var parentName = templateModule ? templateModule.id : undefined;
-
-	var isAPage = !!tagData.subtemplate;
-	loader.normalize(moduleName, parentName).then(function(name){
-		if(isAPage) {
-			parentMap[name] = false;
-		}
-		root.attr("__renderingAssets").push(name);
-	});
-
-	canImport.apply(this, arguments);
 };
 
 [

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ var makeMap = require("./make_map");
 var mergeResponseData = require("./merge_response_data");
 var wait = require("can-wait");
 
-module.exports = function(cfg){
+module.exports = function(cfg, options){
+	options = getOptions(options);
 	var steal = Steal.clone();
 	var loader = global.System = steal.System;
 
@@ -18,7 +19,7 @@ module.exports = function(cfg){
 	steal.config(cfg || {});
 
 	// Ensure the extension is loaded before the main.
-	loadExtension(loader);
+	loadExtension(loader, options);
 
 	function getAutorender(autorender){
 		// startup returns an Array in dev
@@ -137,3 +138,18 @@ module.exports = function(cfg){
 		});
 	};
 };
+
+function getOptions(opts){
+	opts = opts || {};
+
+	if(opts.plugins !== false && !opts.plugins) {
+		opts.plugins = [
+			"canjs"
+		];
+	}
+	if(!opts.plugins) {
+		opts.plugins = [];
+	}
+
+	return opts;
+}

--- a/lib/load_extension.js
+++ b/lib/load_extension.js
@@ -28,13 +28,16 @@ function overrideConfig(loader){
 	};
 }
 
-module.exports = function(loader){
+module.exports = function(loader, options){
 	// Configure the loader to set our overrides.
 	loader.config({
 		paths: {
 			"@ssr": "file:" + path.resolve(path.join(__dirname, "extension.js")),
 			"@ssr/*": "file:" + path.resolve(path.join(__dirname, "/*.js")),
 			"@ssr/system-config": "file:" + path.resolve(path.join(__dirname, "system_config.js"))
+		},
+		map: {
+			"can-ssr-plugin-canjs": "@ssr/plugins/canjs"
 		},
 		configDependencies: [
 			"@ssr/system-config"
@@ -65,10 +68,22 @@ module.exports = function(loader){
 			}
 
 
-			return loader.import("@ssr").then(function(){
-				return loaderImport.apply(loader, args);
-			});
+			return loader.import("@ssr")
+				.then(function(){
+					return Promise.all(options.plugins.map(function(name){
+						return loader.import(pluginName(name), {
+							name: loader.main
+						});
+					}));
+				})
+				.then(function(){
+					return loaderImport.apply(loader, args);
+				});
 		}
 		return loaderImport.apply(this, arguments);
 	};
 };
+
+function pluginName(name){
+	return "can-ssr-plugin-" + name;
+}

--- a/lib/plugins/canjs.js
+++ b/lib/plugins/canjs.js
@@ -1,0 +1,83 @@
+var loader = require("@loader");
+var stache = require("can/view/stache/stache");
+require("can/view/import/import");
+var helpers = require("@ssr/bundles");
+
+// Bundle helpers
+var findBundle = helpers.findBundle;
+var bundles = helpers.bundles;
+var parentMap = helpers.parentMap;
+
+function isProduction(options){
+	var prod = process.env.NODE_ENV === "production";
+	if(prod) {
+		return options.fn(this);
+	} else {
+		return options.inverse(this);
+	}
+}
+
+function assetHelper(type){
+	var state = this;
+	var assets = this.attr("__renderingAssets");
+	var complete = this.attr("__renderingComplete");
+	var frag = document.createDocumentFragment();
+
+	if(complete) {
+		var inserted = {};
+		assets.each(function(moduleName){
+			var bundle = findBundle(moduleName) || bundles[moduleName];
+
+			if(bundle) {
+				Object.keys(bundle).forEach(function(childName){
+					var asset = bundle[childName];
+					if(asset && asset.type === type && !inserted[asset.id]) {
+						inserted[asset.id] = true;
+						var node = asset.value.call(state);
+						node.setAttribute("asset-id", asset.id);
+						frag.appendChild(node);
+					}
+				});
+			}
+		});
+
+		var globals = bundles["@global"];
+		Object.keys(globals).forEach(function(moduleName){
+			var asset = globals[moduleName];
+			if(asset.type === type) {
+				var node = asset.value.call(state);
+				if(node.setAttribute) {
+					node.setAttribute("asset-id", "@" + asset.type);
+				}
+				frag.appendChild(node);
+			}
+		});
+	}
+
+	return frag;
+}
+
+stache.registerHelper("asset", assetHelper);
+stache.registerHelper("isProduction", isProduction);
+
+/**
+ * Overwrite can-import to mark pages as rendering assets.
+ */
+var canImport = can.view.callbacks._tags["can-import"];
+can.view.callbacks._tags["can-import"] = function(el, tagData){
+	var root = tagData.scope.attr("%root") || tagData.scope.attr("@root");
+	var moduleName = el.getAttribute("from");
+	var templateModule = tagData.options.attr("helpers.module");
+	var parentName = templateModule ? templateModule.id : undefined;
+
+	var isAPage = !!tagData.subtemplate;
+	loader.normalize(moduleName, parentName).then(function(name){
+		if(isAPage) {
+			parentMap[name] = false;
+		}
+		root.attr("__renderingAssets").push(name);
+	});
+
+	canImport.apply(this, arguments);
+};
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout 10000 && mocha test/react_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout 10000 && mocha test/react_test.js --timeout 10000 && mocha test/plugin_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -1,0 +1,24 @@
+var canSsr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+
+describe("Using custom plugins", function(){
+	before(function(){
+		this.render = canSsr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "plugins/index.stache!done-autorender",
+		}, {
+			plugins: [ "foo" ]
+		});
+	});
+
+	it("basics works", function(done){
+		this.render("/").then(function(result){
+			var node = helpers.dom(result.html);
+
+			var foo = node.getElementById("foo");
+			assert(foo, "foo element is shown because the plugin loaded");
+		}).then(done);
+	});
+});

--- a/test/tests/node_modules/can-ssr-plugin-foo/foo.js
+++ b/test/tests/node_modules/can-ssr-plugin-foo/foo.js
@@ -1,0 +1,1 @@
+require("@loader").fooPluginInstalled = true;

--- a/test/tests/node_modules/can-ssr-plugin-foo/package.json
+++ b/test/tests/node_modules/can-ssr-plugin-foo/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "can-ssr-plugin-foo",
+	"main": "foo",
+	"version": "1.0.0"
+}

--- a/test/tests/package.json
+++ b/test/tests/package.json
@@ -4,7 +4,8 @@
   "main": "progressive/index.stache!done-autorender",
   "dependencies": {
     "can": "2.3.0-pre.1",
-    "done-autorender": "0.0.7"
+    "done-autorender": "0.0.7",
+    "can-ssr-plugin-foo": "1.0.0"
   },
   "system": {
     "paths": { "./app-map": "../../app-map.js" },

--- a/test/tests/plugins/index.stache
+++ b/test/tests/plugins/index.stache
@@ -1,0 +1,12 @@
+<html>
+	<head>
+		<title>envs test</title>
+	</head>
+	<body>
+		<can-import from="plugins/state" export-as="viewModel" />
+
+		{{#if foo}}
+		<div id="foo">I am foo</div>
+		{{/if}}
+	</body>
+</html>

--- a/test/tests/plugins/state.js
+++ b/test/tests/plugins/state.js
@@ -1,0 +1,13 @@
+var AppMap = require("app-map");
+
+var loader = require("@loader");
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+module.exports = AppMap.extend({
+
+	foo: function(){
+		return !!loader.fooPluginInstalled;
+	}
+
+});


### PR DESCRIPTION
The plugin API allows you to specify can-ssr plugins that will run in
the context of your app while server-side rendering. These are useful
for providing extra features.

For example the **canjs** plugin (included by default) provides some
stache helpers like `{{isProduction}}` and `{{asset "css"}}`.

Other frameworks might want to provide their own plugins. They can do so
by publishing a package `can-ssr-plugin-FOO` where FOO is the name of
the plugin that will be provided in options.

To use a plugin include a second argument of options with an array of
plugins to include. For example:

```js
var ssr = require("can-ssr");

var render = ssr({}, {
	plugins: ["foo"]
});
```

Would include the `can-ssr-plugin-foo` plugin.

If you would like to exclude all plugins, including the canjs plugin,
   make `plugins: false` the option.

Closes #87