### PR TITLE
Implements can-ssr/import

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,0 +1,20 @@
+var loader = require("@loader");
+var parentMap = loader.has("@ssr/bundles") ?
+	loader.get("@ssr/bundles").default.parentMap : undefined;
+
+module.exports = function(moduleName, options){
+	var parentName = options ? options.name : undefined;
+
+	return loader.normalize(moduleName, parentName).then(function(name){
+		if(parentMap) {
+			parentMap[name] = false;
+		}
+
+		if(typeof canWait !== "undefined" && canWait.data){
+			canWait.data({ page: name });
+		}
+
+		return loader.import(moduleName, options);
+	});
+
+};

--- a/lib/merge_response_data.js
+++ b/lib/merge_response_data.js
@@ -1,10 +1,36 @@
 
+/**
+ * canWait returns an array of responses
+ * These are all of the datas added via canWait.data({})
+ *
+ * We are using namespacing so that different libraries can all
+ * add their own types of data. can-ssr knows of 2 types:
+ *
+ * **pageData**: This is data that will be part of the INLINE_CACHE
+ *
+ * **page**: These are the module names of pages dynamically imported like
+ * app/orders/orders
+ *
+ * This module's responsibility is to copy over the responses onto the
+ * AppViewModel instance so that they can be used by the stache helpers.
+ */
+
 module.exports = function(state, responses){
 	responses = responses || [];
+
+	// pageData
 	var pageData = state.__pageData = state.__pageData || {};
+
+	// renderingAssets
+	var renderingAssets = state.__renderingAssets = state.__renderingAssets || [];
+
 	responses.forEach(function(resp){
 		if(resp.pageData) {
 			can.extend(pageData, resp.pageData);
+		}
+
+		if(resp.page && renderingAssets.indexOf(resp.page) === -1) {
+			renderingAssets.push(resp.page);
 		}
 	});
 };

--- a/lib/plugins/canjs.js
+++ b/lib/plugins/canjs.js
@@ -25,6 +25,7 @@ function assetHelper(type){
 
 	if(complete) {
 		var inserted = {};
+
 		assets.each(function(moduleName){
 			var bundle = findBundle(moduleName) || bundles[moduleName];
 
@@ -80,4 +81,3 @@ can.view.callbacks._tags["can-import"] = function(el, tagData){
 
 	canImport.apply(this, arguments);
 };
-

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout 10000 && mocha test/react_test.js --timeout 10000 && mocha test/plugin_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/async_test.js --timeout 10000 && mocha test/jquery_test.js --timeout 10000 && mocha test/react_test.js --timeout 10000 && mocha test/plugin_test.js --timeout 10000 && mocha test/plainjs_test.js --timeout 10000 && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/test/plainjs_test.js
+++ b/test/plainjs_test.js
@@ -1,0 +1,41 @@
+var canSsr = require("../lib/");
+var helpers = require("./helpers");
+var assert = require("assert");
+var path = require("path");
+
+describe("rendering a JavaScript main", function(){
+	before(function(){
+		this.render = canSsr({
+			config: "file:" + path.join(__dirname, "tests", "package.json!npm"),
+			main: "plain/main",
+			paths: {
+				"$css": "file:" + path.resolve(__dirname + "/tests/less_plugin.js"),
+				"can-ssr/import": "file:" + path.resolve(__dirname + "/../import.js")
+			}
+		});
+	});
+
+	it("returns only the css needed for the request", function(done){
+		var render = this.render;
+
+		var checkCount = function(result, expected, message){
+			var node = helpers.dom(result.html);
+
+			var styles = helpers.count(node, function(el){
+				return el.nodeName === "STYLE";
+			});
+
+			assert.equal(styles, expected, message + " | " + styles +
+						 " !== " + expected);
+		};
+
+		render("/orders").then(function(result){
+			checkCount(result, 2, "There should be 2 styles for the orders page");
+
+			return render("/");
+		}).then(function(result){
+			checkCount(result, 1, "There should only be 1 style for the root page");
+		})
+		.then(done, done);
+	});
+});

--- a/test/tests/plain/appstate.js
+++ b/test/tests/plain/appstate.js
@@ -1,0 +1,5 @@
+var AppMap = require("app-map");
+
+module.exports = AppMap.extend({
+
+});

--- a/test/tests/plain/body.stache
+++ b/test/tests/plain/body.stache
@@ -1,0 +1,3 @@
+<can-import from="plain/main.css!"/>
+
+<div id="app"></div>

--- a/test/tests/plain/head.stache
+++ b/test/tests/plain/head.stache
@@ -1,0 +1,3 @@
+<title>plainjs</title>
+
+{{asset "css"}}

--- a/test/tests/plain/home/home.js
+++ b/test/tests/plain/home/home.js
@@ -1,0 +1,11 @@
+var can = require("can");
+var template = require("./home.stache!");
+
+var ViewModel = can.Map.extend({
+});
+
+can.Component.extend({
+	tag: "home-page",
+	template: template,
+	viewModel: ViewModel
+});

--- a/test/tests/plain/home/home.stache
+++ b/test/tests/plain/home/home.stache
@@ -1,0 +1,1 @@
+<div id="home">You are {{page}}</div>

--- a/test/tests/plain/main.css
+++ b/test/tests/plain/main.css
@@ -1,0 +1,3 @@
+body {
+	color: black;
+}

--- a/test/tests/plain/main.js
+++ b/test/tests/plain/main.js
@@ -1,0 +1,30 @@
+import AppViewModel from "plain/appstate";
+import $ from "jquery";
+
+import importPage from "can-ssr/import";
+import "plain/routes";
+
+import headTemplate from "plain/head.stache!";
+import bodyTemplate from "plain/body.stache!";
+
+export let viewModel = AppViewModel;
+
+var pages = {
+	"home": "<home-page></home-page",
+	"orders": "<order-history></order-history>"
+};
+
+export function render(doc, state){
+	$(doc.head).html(headTemplate(state));
+	var body = $(doc.body);
+	body.html(bodyTemplate(state));
+
+	var page = state.attr("page");
+	var module = "plain/" + page + "/";
+
+	importPage(module, { name: System.main }).then(function(){
+		body.find("#app").html(
+			can.stache(pages[page])(state)
+		);
+	});
+}

--- a/test/tests/plain/orders/orders.css
+++ b/test/tests/plain/orders/orders.css
@@ -1,0 +1,3 @@
+order-history {
+	background: blue;
+}

--- a/test/tests/plain/orders/orders.js
+++ b/test/tests/plain/orders/orders.js
@@ -1,0 +1,36 @@
+var can = require("can");
+var template = require("./orders.stache!");
+require("./orders.css!");
+require("can/map/define/");
+
+var ViewModel = can.Map.extend({
+	define: {
+		orders: {
+			Value: can.List,
+			get: function(list){
+				var id = "foo";
+				var dfd = new can.Deferred();
+				canWait.data(dfd.then(function(value){
+					return {
+						pageData: {
+							restaurant: {
+								"{\"foo\":\"foo\"}": value
+							}
+						}
+					}
+				}));
+
+				list.replace(dfd);
+				dfd.resolve([ { a: "a" }, { b: "b" } ]);
+
+				return list;
+			}
+		}
+	}
+});
+
+can.Component.extend({
+	tag: "order-history",
+	template: template,
+	viewModel: ViewModel
+});

--- a/test/tests/plain/orders/orders.stache
+++ b/test/tests/plain/orders/orders.stache
@@ -1,0 +1,5 @@
+<div id="orders">
+{{#each orders}}
+	<div>order {{%index}}</div>
+{{/each}}
+</div>

--- a/test/tests/plain/routes.js
+++ b/test/tests/plain/routes.js
@@ -1,0 +1,4 @@
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+route(":page", { page: "home" });


### PR DESCRIPTION
This implements can-ssr/import, a module that can be used for
dynamically importing modules. Use this instead of System.import to let
ssr know that you are importing a separate page, thus allowing it to
track which css is associated with the request. Closes #88