### PR TITLE
Test programatically use of can-ssr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ __Note:__ Make sure the ssr middleware is the last middleware in the chain but b
 ```js
 var render = require("can-ssr")({
   config: __dirname + "/public/package.json!npm",
-  main: "index.stache!"
+  main: "index.stache!done-autorender"
 });
 
 render("/orders").then(function(result){

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000 && mocha test/make_rendered_html.js",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jshint": "jshint lib/.  test/*.js --config",
     "test:only": "grunt && npm run test:node && npm run test:browser",
     "test": "npm run jshint && npm run test:only",
-    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000 && mocha test/make_rendered_html.js",
+    "test:node": "mocha --timeout 10000 test/test.js && mocha --timeout 10000 test/test_envs.js && mocha test/server_test.js --timeout 10000 && mocha test/middleware_test.js --timeout 10000 && mocha test/can-serve_test.js --timeout 60000 && mocha --timeout 60000 test/make_rendered_html.js",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",

--- a/test/make_rendered_html.js
+++ b/test/make_rendered_html.js
@@ -1,13 +1,23 @@
 var path = require("path");
+var ssr = require("../lib");
+var assert = require("assert");
 
-var render = require("../lib/main")({
+var render = ssr({
 	config: __dirname + "/tests/package.json!npm",
-	main: "progressive/index.stache!",
+	main: "progressive/index.stache!done-autorender",
 	paths: {
 		"$css": path.resolve(__dirname + "/tests/less_plugin.js")
 	}
 });
 
-render("/orders").then(function(html){
-	console.log(html);
+describe('renders html programatically', function() {
+	it('works', function() {
+		return render("/orders").then(function(result) {
+			assert.deepEqual(Object.keys(result), ['state', 'html']);
+			assert.equal(result.state.attr('statusCode'), 200);
+
+			var hasOrderHistory = result.html.indexOf('<order-history>') !== -1;
+			assert(hasOrderHistory, 'it should render order history page');
+		});
+	});
 });


### PR DESCRIPTION
There were a few issues with the make_rendered_html file in the tests folder:

- The require to get the ssr main module was wrong (fixed to load lib/index instead of lib/main)
- The `main` module name needs the `done-autorender` plugin name at the end otherwise `can-ssr` will complain about a missing `AppViewModel`

I also fixed the example in the README file to include `done-autorender` in the main module name.

@matthewp let me know if you have any feedback about this, it seems like a nice to have. 