### PR TITLE
Pass in the raw http request to createState

### DIFF
--- a/lib/create_state.js
+++ b/lib/create_state.js
@@ -1,0 +1,36 @@
+var url = require("url");
+
+// This is the legacy createState function for backwards compatibility.
+module.exports = function(main){
+	return function(request){
+		var ViewModel = main.viewModel;
+
+		if(!ViewModel) {
+			throw new Error("can-ssr cannot render your application " +
+							"without a viewModel defined. " +
+							"See the guide for information. " +
+							"http://donejs.com/Guide.html#section_Createatemplateandmainfile");
+		}
+
+		var pathname = url.parse(request.url).href;
+		var params = can.extend(can.route.deparam(pathname), {
+			__renderingAssets: [],
+			env: process.env,
+			request: request
+		});
+
+		var state = new ViewModel(params);
+
+		if(typeof state.pageStatus === 'function' &&
+				!state.attr('statusCode') &&
+				!can.isEmptyObject(can.route.routes)) {
+			if(!params.route) {
+				state.pageStatus(404, 'Not found');
+			} else {
+				state.pageStatus(200);
+			}
+		}
+		return state;
+
+	};
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var trigger = require("./trigger");
 var makeMap = require("./make_map");
 var mergeResponseData = require("./merge_response_data");
 var wait = require("can-wait");
+var makeCreateState = require("./create_state");
 
 module.exports = function(cfg, options){
 	options = getOptions(options);
@@ -21,30 +22,35 @@ module.exports = function(cfg, options){
 	// Ensure the extension is loaded before the main.
 	loadExtension(loader, options);
 
-	function getAutorender(autorender){
+	function getMainModule(main){
 		// startup returns an Array in dev
-		autorender = Array.isArray(autorender) ? autorender[0] : autorender;
-		return autorender.importPromise || Promise.resolve(autorender);
+		main = Array.isArray(main) ? main[0] : main;
+		return main.importPromise || Promise.resolve(main);
 	}
 
-	var startup = steal.startup().then(function(autorender){
-		// If live-reload is enabled we need to get a new autorender each
+	var startup = steal.startup().then(function(main){
+		// If live-reload is enabled we need to get a new main each
 		// time a reload cycle is complete.
 		if(loader.has("live-reload")) {
 			var importOpts = {name: "@ssr"};
 			loader.import("live-reload", importOpts).then(function(reload){
 				reload(function(){
-					startup = loader.import(loader.main).then(getAutorender);
+					startup = loader.import(loader.main).then(getMainModule);
 				});
 			});
 		}
-		return getAutorender(autorender);
+		return getMainModule(main);
 	});
 
-	return function(url){
-		return startup.then(function(autorender){
-			var serializeFromBody = !!(autorender.renderAsync ||
-									   autorender.serializeFromBody);
+	return function(requestOrUrl){
+		return startup.then(function(main){
+			// Setup options
+			var serializeFromBody = !!(main.renderAsync ||
+									   main.serializeFromBody);
+			var request = typeof requestOrUrl === "string" ?
+				{ url: requestOrUrl } : requestOrUrl;
+
+			// Create the document
 			var doc = new document.constructor();
 			if(!serializeFromBody) {
 				doc.head = doc.createElement("head");
@@ -52,44 +58,16 @@ module.exports = function(cfg, options){
 			}
 
 			// New API is createState, if not fall back to the old API
-			var createState = autorender.createState || function(request){
-				var ViewModel = autorender.viewModel;
-
-				if(!ViewModel) {
-					throw new Error("can-ssr cannot render your application " +
-									"without a viewModel defined. " +
-									"See the guide for information. " +
-									"http://donejs.com/Guide.html#section_Createatemplateandmainfile");
-				}
-
-				var state = new ViewModel();
-				var params = can.route.deparam(url);
-
-				state.attr(params);
-				state.attr("__renderingAssets", []);
-				state.attr("env", process.env);
-
-				if(typeof state.pageStatus === 'function' &&
-						!state.attr('statusCode') &&
-						!can.isEmptyObject(can.route.routes)) {
-					if(!params.route) {
-						state.pageStatus(404, 'Not found');
-					} else {
-						state.pageStatus(200);
-					}
-				}
-				return state;
-
-			};
+			var createState = main.createState || makeCreateState(main);
 
 			// Support both the legacy autorender API and the new API
 			// specified by https://github.com/canjs/can-ssr/issues/80
-			var useLegacyAPI = autorender.legacy !== false &&
-				autorender.renderAsync;
-			var render = !useLegacyAPI ? autorender.render.bind(autorender) :
+			var useLegacyAPI = main.legacy !== false &&
+				main.renderAsync;
+			var render = !useLegacyAPI ? main.render.bind(main) :
 				function(){
-				var render = autorender.render;
-				return autorender.renderAsync(render, state, {}, doc)
+				var render = main.render;
+				return main.renderAsync(render, state, {}, doc)
 					.then(function(result){
 						(result.canWaitData || []).forEach(function(data){
 							canWait.data(data);
@@ -101,7 +79,7 @@ module.exports = function(cfg, options){
 
 			var state, stateMap;
 			var run = function(){
-				state = createState({ url: url });
+				state = createState(request);
 				stateMap = makeMap(state);
 
 				Promise.resolve(render(doc, state)).then(null, function(errors){
@@ -112,7 +90,6 @@ module.exports = function(cfg, options){
 			};
 
 			return wait(run)
-			//return Promise.resolve(render(doc, state))
 				.then(function(resp){
 					mergeResponseData(stateMap, resp);
 				})

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -1,7 +1,6 @@
 require('./websocket');
 
 var path = require('path');
-var url = require('url');
 var os = require('os');
 
 var ssr = require('./../index.js');
@@ -30,11 +29,9 @@ module.exports = function(system) {
 	var render = ssr(system);
 
 	return function (req, res, next) {
-		var pathname = url.parse(req.url).href;
-
 		XHR.base = req.protocol + '://' + req.get('host');
 
-		render(pathname).then(function(result) {
+		render(req).then(function(result) {
 			var dt = system.doctype || doctype;
 			var status = result.state.attr('statusCode') || 200;
 

--- a/test/middleware_test.js
+++ b/test/middleware_test.js
@@ -20,6 +20,7 @@ describe('standalone middleware test', function() {
 			request('http://localhost:5500', function(err, res, body) {
 				assert.equal(res.statusCode, 200);
 				assert.ok(/You are home/.test(body), 'Got body');
+				assert.ok(/Showing: \//.test(body), 'The request object is accessible from the AppViewModel');
 				server.close(done);
 			});
 		});

--- a/test/tests/progressive/index.stache
+++ b/test/tests/progressive/index.stache
@@ -30,6 +30,10 @@
 
 		{{#if err}} {{throwError}} {{/if}}
 
+		{{#if request}}
+			<div>Showing: {{request.url}}</div>
+		{{/if}}
+
 		{{asset "inline-cache"}}
 	</body>
 </html>


### PR DESCRIPTION
This changes it so that the main module receives the raw http request
and not a request-like object. This means you can do:

```js
exports.createState = function(request){
	// Do whatever you want with request
};
```

Also, in the case of done-autorender, a `request` property is set on the
AppViewModel.

Fixes #93