### PR TITLE
Override can.document when rendering

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var makeMap = require("./make_map");
 var mergeResponseData = require("./merge_response_data");
 var wait = require("can-wait");
 var makeCreateState = require("./create_state");
+var makeWaitOptions = require("./make_wait_options");
 
 module.exports = function(cfg, options){
 	options = getOptions(options);
@@ -89,7 +90,7 @@ module.exports = function(cfg, options){
 				});
 			};
 
-			return wait(run)
+			return wait(run, makeWaitOptions(doc))
 				.then(function(resp){
 					mergeResponseData(stateMap, resp);
 				})

--- a/lib/make_wait_options.js
+++ b/lib/make_wait_options.js
@@ -1,0 +1,18 @@
+var Override = require("can-wait").Override;
+
+module.exports = function(doc){
+	var overrides = [];
+
+	// If there's a can global
+	if(typeof can !== "undefined") {
+		overrides.push(function(){
+			return new Override(can, "document", function(){
+				return doc;
+			});
+		});
+	}
+
+	return {
+		overrides: overrides
+	};
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/canjs/ssr",
   "devDependencies": {
     "documentjs": "^0.3.0",
-    "done-autorender": "^0.3.0",
+    "done-autorender": "^0.6.0-pre.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^0.8.0",

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,13 @@ describe("rendering an app", function(){
 			assert.equal(found["progressive/main.css!$css"], true, "Found the main css");
 			assert.equal(found["progressive/orders/orders.css!$css"], true, "Found the orders bundle css");
 			assert.equal(found["@inline-cache"], true, "The inline-cache was registered");
+
+
+			var totalsEl = helpers.find(node, function(el){
+				return el.getAttribute && el.getAttribute("id") === "totals";
+			});
+			assert.ok(totalsEl, "an element that was conditionally added in the 'inserted' event is rendered");
+
 		}).then(done);
 	});
 

--- a/test/tests/progressive/orders/orders.js
+++ b/test/tests/progressive/orders/orders.js
@@ -13,10 +13,23 @@ var ViewModel = can.Map.extend({
 				this.attr("%root").pageData("restaurant", { foo: id }, dfd);
 
 				list.replace(dfd);
-				dfd.resolve([ { a: "a" }, { b: "b" } ]);
+				dfd.resolve([ { a: "a", v: 2 }, { b: "b", v: 5 } ]);
 
 				return list;
 			}
+		},
+		totals: {
+			get: function(){
+				var orders = this.attr("orders");
+				var totals = 0;
+				orders.each(function(order){
+					totals += order.v;
+				});
+				return totals;
+			}
+		},
+		showTotals: {
+			value: false
 		}
 	}
 });
@@ -24,5 +37,10 @@ var ViewModel = can.Map.extend({
 can.Component.extend({
 	tag: "order-history",
 	template: template,
-	viewModel: ViewModel
+	viewModel: ViewModel,
+	events: {
+		inserted: function(){
+			this.viewModel.attr("showTotals", true);
+		}
+	}
 });

--- a/test/tests/progressive/orders/orders.stache
+++ b/test/tests/progressive/orders/orders.stache
@@ -3,3 +3,7 @@
 	<div>order {{%index}}</div>
 {{/each}}
 </div>
+
+{{#if showTotals}}
+	<div id='totals'>{{totals}}</div>
+{{/if}}


### PR DESCRIPTION
Previously done-autorender handled setting can.document to the request's
document by waiting to insert the fragment until it had been fully
rendered. This meant that can.document was only changed once and
inserted events were only fired once.

This was a bug because it meant if async activity was triggered by
something that happened within an `inserted` event, that activity would
not be rendered on the server.

With the change to use can-wait we need to be able to set can.document
every time a different task is performed (a setTimeout, a Promise,
		whatever). can-wait supports passing in an array of Overrides
that will be set for each task. So the fix is to pass in an override
that overrides can.document.