### PR TITLE
Add tests and functionality for proxying websockets

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -15,12 +15,7 @@ module.exports = function (options) {
 	}
 
 	if (options.proxy) {
-		var apiPath = options.proxyTo || '/api';
-		if(apiPath.charAt(0) !== '/') {
-			apiPath = '/' + apiPath;
-		}
-
-		app.use(apiPath, proxy(options.proxy));
+		proxy(app, options);
 	}
 
 	var system = {

--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -1,11 +1,35 @@
 var httpProxy = require('http-proxy');
 var proxy = httpProxy.createProxyServer();
 
-module.exports = function (target) {
-	return function (req, res) {
-		proxy.web(req, res, {
-			target: target,
-			changeOrigin: true
+module.exports = function (app, options) {
+	var apiPath = options.proxyTo || '/api';
+	var oldListen = app.listen;
+	var middleware = function(target) {
+		return function(req, res) {
+			proxy.web(req, res, {
+				target: target,
+				changeOrigin: true
+			});
+		};
+	};
+
+	if(apiPath.charAt(0) !== '/') {
+		apiPath = '/' + apiPath;
+	}
+
+	app.use(apiPath, middleware(options.proxy));
+	app.use('/socket.io/', middleware(options.proxy + '/socket.io/'));
+
+
+	app.listen =  function() {
+		var server = oldListen.apply(this, arguments);
+
+		server.on('upgrade', function(req,res){
+		  proxy.ws(req, res, {
+		    target: options.proxy
+		  });
 		});
+
+		return server;
 	};
 };

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "jquery": "^1.11.3",
     "jshint": "^2.8.0",
     "mocha": "^2.2.4",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "request": "^2.61.0",
+    "socket.io": "^1.4.1",
+    "socket.io-client": "^1.4.1",
     "steal-qunit": "0.0.4",
     "steal-tools": "^0.13.0-pre.0",
-    "testee": "^0.2.0",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "testee": "^0.2.0"
   },
   "dependencies": {
     "can": "^2.3.0-pre || ^2.3.0-beta || ^2.3.0",


### PR DESCRIPTION
This adds tests and the ability to proxy SocketIO websocket connections. Turned out that I only had a rough draft in a branch and it never made it into a release. For https://github.com/donejs/donejs/issues/463