### PR TITLE
Merge pageData two levels deep

### DIFF
--- a/lib/merge_response_data.js
+++ b/lib/merge_response_data.js
@@ -26,7 +26,14 @@ module.exports = function(state, responses){
 
 	responses.forEach(function(resp){
 		if(resp.pageData) {
-			can.extend(pageData, resp.pageData);
+			Object.keys(resp.pageData).forEach(function(key){
+				var child = resp.pageData[key];
+				var parent = pageData[key];
+				if(!parent) {
+					parent = pageData[key] = {};
+				}
+				can.extend(parent, child);
+			});
 		}
 
 		if(resp.page && renderingAssets.indexOf(resp.page) === -1) {

--- a/test/async_test.js
+++ b/test/async_test.js
@@ -25,7 +25,10 @@ describe("async rendering", function(){
 
 			var cache = helpers.getInlineCache(node);
 
-			assert(cache.restaurant, "restaurant key was added");
+			assert(cache.restaurant["{\"foo\":\"foo\"}"],
+				  "foo key added for restaurant");
+			assert(cache.restaurant["{\"bar\":\"bar\"}"],
+				  "bar key added for restaurant");
 		}).then(done, done);
 	});
 });

--- a/test/tests/async/orders/orders.js
+++ b/test/tests/async/orders/orders.js
@@ -20,6 +20,16 @@ var ViewModel = can.Map.extend({
 					};
 				}));
 
+				setTimeout(function(){
+					canWait.data({
+						pageData: {
+							restaurant: {
+								"{\"bar\":\"bar\"}": {}
+							}
+						}
+					});
+				});
+
 				list.replace(dfd);
 				dfd.resolve([ { a: "a" }, { b: "b" } ]);
 


### PR DESCRIPTION
This fixes #105

Ideally this responsibility should be with the plugin that implements
INLINE_CACHE, like can-connect. When We do #108 this code can be removed
and the same thing done in that project.