### PR TITLE
Exposed a proxy setting to ignore SSL cert details like signer and ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Available options:
 - __-d, --develop__ - Also starts a live-reload server
 - __-p, --proxy__ <url> - Proxy a local path (default: `/api`) to the given URL (e.g. `http://api.myapp.com`)
 - __-t, --proxy-to <path>__ - Set the proxy endpoint (default: `/api`)
+- __--proxy-no-cert-check__ - Turn off SSL certificate verification
 
 ## Usage
 

--- a/bin/can-serve
+++ b/bin/can-serve
@@ -14,6 +14,7 @@ program.version(pkg.version)
   .option('-p, --port <port>', 'The server port')
   .option('-r, --proxy <url>', 'A URL to an API that should be proxied')
   .option('-t, --proxy-to <path>', 'The path to proxy to (default: /api)')
+  .option('--proxy-no-cert-check', 'Turn off SSL certificate verification')
   .option('-l, --no-live-reload', 'Turn off live-reload')
   .option('--live-reload-port <port>', 'Port to use for live-reload')
   .option('--steal-tools-path <path>', 'Location of your steal-tools')
@@ -27,6 +28,7 @@ var options = {
 if(program.proxy) {
   options.proxy = program.proxy;
   options.proxyTo = program.proxyTo;
+  options.proxyCertCheck = program.proxyCertCheck;
 }
 
 // Spawn a child process in development mode

--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -8,7 +8,8 @@ module.exports = function (app, options) {
 		return function(req, res) {
 			proxy.web(req, res, {
 				target: target,
-				changeOrigin: true
+				changeOrigin: true,
+				secure: options.proxyCertCheck
 			});
 		};
 	};


### PR DESCRIPTION
…piration.

The proxy feature doesn't currently work if the target has a self-signed or expired certificate. This PR exposes a `--proxy-no-cert-check` switch to ignore certificate verification.