### PR TITLE
Conditionally call doc.__addSerializerAndParser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,8 +53,13 @@ module.exports = function(cfg, options){
 
 			// Create the document
 			var doc = new document.constructor();
-			doc.__addSerializerAndParser(document.__serializer,
-										document.__parser);
+
+			// doc.__addSerializerAndParser is not available in CanJS older than 2.3.11
+			if (typeof doc.__addSerializerAndParser === "function") {
+				doc.__addSerializerAndParser(document.__serializer,
+											document.__parser);
+			}
+
 			if(!serializeFromBody) {
 				doc.head = doc.createElement("head");
 				doc.documentElement.insertBefore(doc.head, doc.body);

--- a/test/tests/envs/index.stache
+++ b/test/tests/envs/index.stache
@@ -5,6 +5,6 @@
 	<body>
 		<can-import from="envs/state" as="viewModel" />
 
-		<span>hello {{env}}</span>
+		<span>hello {{envs}}</span>
 	</body>
 </html>

--- a/test/tests/envs/state.js
+++ b/test/tests/envs/state.js
@@ -4,7 +4,7 @@ var route = require("can/route/route");
 require("can/route/pushstate/pushstate");
 
 module.exports = AppMap.extend({
-	env: function(){
+	envs: function(){
 		return System.FOO;
 	}
 });


### PR DESCRIPTION
It is not available in CanJS versions older than 2.3.11

Closes #131.