### PR TITLE
Remove special envs configuration

### DIFF
--- a/lib/load_extension.js
+++ b/lib/load_extension.js
@@ -6,28 +6,6 @@ global.navigator = global.navigator || {
 	userAgent: "Mozilla/5.0 " + "can-ssr/" + pkg.version
 };
 
-// Override config to prevent the baseURL from being set to something that
-// can't be used to render.
-function overrideConfig(loader){
-	var config = loader.config;
-	loader.config = function(){
-		var res = config.apply(this, arguments);
-
-		var envs = this.envs;
-		if(envs) {
-			Object.keys(envs).forEach(function(key){
-				var config = envs[key];
-				if(config.baseURL) {
-					loader.renderingBaseURL = config.baseURL;
-					delete config.baseURL;
-				}
-			});
-		}
-
-		return res;
-	};
-}
-
 module.exports = function(loader, options){
 	// Configure the loader to set our overrides.
 	loader.config({
@@ -46,8 +24,6 @@ module.exports = function(loader, options){
 
 	// Alias our module with the default, that way we can require can
 	aliasNpm(loader, path.resolve(path.join(__dirname, "..")));
-
-	overrideConfig(loader);
 
 	// Ensure the extension loads before the main.
 	var loaderImport = loader.import;

--- a/test/tests/package.json
+++ b/test/tests/package.json
@@ -11,7 +11,7 @@
     "paths": { "./app-map": "../../app-map.js" },
     "envs": {
       "someenv": {
-		"baseURL": "http://example.com/",
+		"renderingBaseURL": "http://example.com/",
 		"FOO": "bar"
       }
     }


### PR DESCRIPTION
Previously we were hooking on loader.config so that we could set:

```js
"envs": {
	"window-production": {
		"baseURL": "path/to/base"
	}
}
```

But this is technical incorrectly and causes bugs, instead it should be:

```js
"envs": {
	"server-production": {
		"renderingBaseURL": "path/to/base"
	}
}
```

This is for https://github.com/donejs/donejs/issues/554